### PR TITLE
feat: add OINT mission control toolset

### DIFF
--- a/app/api/oint/apply/route.ts
+++ b/app/api/oint/apply/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+
+let started = false
+
+export async function POST() {
+  started = true
+  return NextResponse.json({ status: 'queued', jobId: 'demo-job' })
+}
+
+export function hasStarted() {
+  return started
+}

--- a/app/api/oint/summary/route.ts
+++ b/app/api/oint/summary/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import type { DashboardData } from '../../../../lib/types.oint'
+
+export async function GET() {
+  const data: DashboardData & Record<string, unknown> = {
+    generatedAt: '2024-04-01T00:00:00Z',
+    pulse: { envs: ['prod', 'stage'], deploysToday: 2, criticalAlerts: 0 },
+    integrationsTop10: [
+      { name: 'Supabase', category: 'database', impact: 88, security: 90, ops: 70, health: 85, coupling: 40, upgrade: 80, logoUrl: '/logos/supabase.svg' },
+      { name: 'Next.js', category: 'framework', impact: 92, security: 88, ops: 75, health: 90, coupling: 60, upgrade: 65, logoUrl: '/logos/nextjs.svg' },
+      { name: 'Redis', category: 'cache', impact: 78, security: 70, ops: 60, health: 80, coupling: 50, upgrade: 75, logoUrl: '/logos/redis.svg' },
+      { name: 'Sentry', category: 'monitoring', impact: 60, security: 65, ops: 55, health: 70, coupling: 30, upgrade: 80, logoUrl: '/logos/sentry.svg' }
+    ],
+    hotspots: [],
+    actions: [
+      { id: 'act-1', title: 'Upgrade Next.js to v14', severity: 'high', rationale: 'Latest security fixes' },
+      { id: 'act-2', title: 'Review Redis configuration', severity: 'medium', rationale: 'Potential performance issues' },
+      { id: 'act-3', title: 'Add tests for new API endpoints', severity: 'low', rationale: 'Improve coverage' }
+    ],
+    ownership: [],
+    topology: {},
+    pipeline: {},
+    security: {},
+    apiSurface: {},
+    docs: {},
+    commitMatrix: {},
+    reliability: { coveragePct: 76, evidenceCompletenessPct: 50, llmStaticAgreementPct: 66 }
+  }
+  return NextResponse.json(data)
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,6 +34,9 @@ export default function Home() {
           >
             View Matrix
           </Link>
+          <Link href="/toolset" className="text-sm text-zinc-400 underline">
+            Apply OINT
+          </Link>
         </div>
         <div className="pt-8 text-sm text-zinc-400 max-w-prose">
           <p>

--- a/app/roaster/page.tsx
+++ b/app/roaster/page.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 'use client'
 import { useEffect, useState, CSSProperties, useRef } from 'react'
+import Link from 'next/link'
 
 type Result = { files: string[] }
 type Comment = { department: string; comment: string; temperature: number }
@@ -372,6 +373,7 @@ export default function RoasterPage() {
             <div className="text-sm text-zinc-400">AI-powered code critique, assisting in project management</div>
           </div>
         </div>
+        <Link href="/toolset" className="text-sm text-zinc-400 underline">Apply OINT</Link>
         <div className="flex flex-wrap items-center gap-8">
           <TemperatureKnob value={level} onChange={setLevel} />
           <div className="flex flex-col gap-2">

--- a/app/toolset/page.tsx
+++ b/app/toolset/page.tsx
@@ -1,0 +1,123 @@
+'use client'
+import { useState } from 'react'
+import { Card, Badge, Metric } from '../../lib/ui'
+import type { DashboardData } from '../../lib/types.oint'
+
+export default function ToolsetPage() {
+  const [data, setData] = useState<DashboardData | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  async function apply() {
+    setLoading(true)
+    try {
+      await fetch('/api/oint/apply', { method: 'POST' })
+      const res = await fetch('/api/oint/summary')
+      const json = (await res.json()) as DashboardData
+      setData(json)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function scoreColor(v: number) {
+    return v >= 80 ? 'text-emerald-400' : v >= 60 ? 'text-amber-400' : 'text-rose-400'
+  }
+
+  function severityColor(s: DashboardData['actions'][number]['severity']) {
+    switch (s) {
+      case 'critical':
+        return 'bg-rose-600'
+      case 'high':
+        return 'bg-rose-500'
+      case 'medium':
+        return 'bg-amber-500'
+      default:
+        return 'bg-emerald-600'
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Toolset — OINT Mission Control</h1>
+      {!data && (
+        <Card className="max-w-md">
+          {loading ? (
+            <div className="flex items-center gap-2">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-600 border-t-emerald-500" />
+              <span className="text-sm">Running OINT analysis…</span>
+            </div>
+          ) : (
+            <button
+              onClick={apply}
+              className="px-4 py-2 bg-emerald-600 text-sm font-medium rounded-lg hover:bg-emerald-500 transition"
+            >
+              Apply OINT
+            </button>
+          )}
+        </Card>
+      )}
+      {data && (
+        <div className="space-y-6">
+          <Card className="flex flex-wrap gap-6 text-sm">
+            <div>Envs: {data.pulse.envs.join(', ')}</div>
+            <div>Deploys today: {data.pulse.deploysToday}</div>
+            <div>Critical alerts: {data.pulse.criticalAlerts}</div>
+          </Card>
+          <Card>
+            <h2 className="text-lg font-semibold mb-4">Top Integrations</h2>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="py-1">Name</th>
+                  <th className="py-1">Impact</th>
+                  <th className="py-1">Security</th>
+                  <th className="py-1">Ops</th>
+                  <th className="py-1">Health</th>
+                  <th className="py-1">Coupling</th>
+                  <th className="py-1">Upgrade</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.integrationsTop10.slice(0, 4).map(row => (
+                  <tr key={row.name} className="border-t border-zinc-800">
+                    <td className="py-1 flex items-center gap-2">
+                      {row.logoUrl && (
+                        <img src={row.logoUrl} alt="" className="h-4 w-4" />
+                      )}
+                      {row.name}
+                    </td>
+                    <td className={`py-1 ${scoreColor(row.impact)}`}>{row.impact}</td>
+                    <td className={`py-1 ${scoreColor(row.security)}`}>{row.security}</td>
+                    <td className={`py-1 ${scoreColor(row.ops)}`}>{row.ops}</td>
+                    <td className={`py-1 ${scoreColor(row.health)}`}>{row.health}</td>
+                    <td className={`py-1 ${scoreColor(row.coupling)}`}>{row.coupling}</td>
+                    <td className={`py-1 ${scoreColor(row.upgrade)}`}>{row.upgrade}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Card>
+          <Card>
+            <h2 className="text-lg font-semibold mb-4">Actions</h2>
+            <ul className="space-y-2">
+              {data.actions.map(a => (
+                <li key={a.id} className="flex items-center gap-2 text-sm">
+                  <Badge className={`${severityColor(a.severity)} text-white`}>{a.severity}</Badge>
+                  <span className="font-medium">{a.title}</span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+          <Card>
+            <h2 className="text-lg font-semibold mb-4">Reliability Gate</h2>
+            <div className="space-y-4">
+              <Metric label="Coverage" value={data.reliability.coveragePct} />
+              <Metric label="Evidence" value={data.reliability.evidenceCompletenessPct} />
+              <Metric label="LLM Agreement" value={data.reliability.llmStaticAgreementPct} />
+            </div>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/types.oint.ts
+++ b/lib/types.oint.ts
@@ -1,0 +1,10 @@
+export type EvidenceRef = { filePath:string; startLine:number; endLine:number; commit:string };
+export type IntegrationRow = { name:string; category:string; impact:number; security:number; ops:number; health:number; coupling:number; upgrade:number; logoUrl?:string; evidence?:EvidenceRef[] };
+export type ActionItem = { id:string; title:string; severity:'critical'|'high'|'medium'|'low'; rationale:string; };
+export type DashboardData = {
+  generatedAt:string;
+  pulse:{ envs:string[]; deploysToday:number; criticalAlerts:number; };
+  integrationsTop10:IntegrationRow[];
+  actions:ActionItem[];
+  reliability:{ coveragePct:number; evidenceCompletenessPct:number; llmStaticAgreementPct:number; };
+};

--- a/lib/ui.tsx
+++ b/lib/ui.tsx
@@ -1,0 +1,23 @@
+import type { HTMLAttributes } from 'react'
+
+export function Card({ className = '', ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={`rounded-xl border border-zinc-800 bg-zinc-900/60 p-4 ${className}`} {...props} />
+}
+
+export function Badge({ className = '', ...props }: HTMLAttributes<HTMLSpanElement>) {
+  return <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ${className}`} {...props} />
+}
+
+export function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between text-sm">
+        <span>{label}</span>
+        <span>{value}%</span>
+      </div>
+      <div className="h-2 bg-zinc-800 rounded">
+        <div className="h-full bg-emerald-500 rounded" style={{ width: `${value}%` }} />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Mission Control dashboard under /toolset with Apply OINT workflow
- stub API routes returning deterministic data for OINT apply and summary
- provide shared OINT types and simple Card/Badge/Metric UI helpers
- link existing pages to new Toolset tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a748e1127083229a58e5f253fc0acb