### PR TITLE
feat: consider docs in Roaster v0.1.7

### DIFF
--- a/app/api/roaster/route.ts
+++ b/app/api/roaster/route.ts
@@ -4,8 +4,12 @@ import { roastRepo } from '../../../lib/openai'
 
 export async function POST(req: Request) {
   try {
-    const { files, level = 0.5 } = await req.json()
-    const comments = await roastRepo(Array.isArray(files) ? files : [], level)
+    const { files, docs = [], level = 0.5 } = await req.json()
+    const comments = await roastRepo(
+      Array.isArray(files) ? files : [],
+      Array.isArray(docs) ? docs : [],
+      level
+    )
     return NextResponse.json({ comments })
   } catch (err: any) {
     return NextResponse.json({ error: err?.message || 'roaster failed' }, { status: 500 })

--- a/app/roaster/page.tsx
+++ b/app/roaster/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import HexBackground from '../../components/HexBackground'
 import { getRoasterState, setRoasterState } from '../../lib/roasterState'
 import { getOintData } from '../../lib/toolsetState'
+import { getDocs } from '../../lib/docsState'
 
 type Result = { files: string[] }
 type Comment = { department: string; comment: string; temperature: number }
@@ -298,10 +299,13 @@ export default function RoasterPage() {
     setHealed(false)
     setRoasting(true)
     try {
+      const docs = await Promise.all(
+        getDocs().map(async d => ({ name: d.name, content: await d.text() }))
+      )
       const res = await fetch('/api/roaster', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ files: result.files, level })
+        body: JSON.stringify({ files: result.files, docs, level })
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'roaster failed')
@@ -388,7 +392,7 @@ export default function RoasterPage() {
         <div className="flex items-start justify-between">
           <h1 className="text-2xl font-semibold tracking-tight">Roaster</h1>
           <div className="text-right leading-tight">
-            <div className="text-5xl font-bold">Roaster v0.1.6</div>
+            <div className="text-5xl font-bold">Roaster v0.1.7</div>
             <div className="text-sm text-zinc-400">AI-powered code critique, assisting in project management</div>
           </div>
         </div>

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -72,13 +72,21 @@ export async function summarizeRepo(fileList: string[]): Promise<RepoAnalysis> {
   return JSON.parse(txt)
 }
 
-export async function roastRepo(fileList: string[], level = 0.5): Promise<RoastComment[]> {
-  const content = fileList.slice(0, 200).join('\n')
+export async function roastRepo(
+  fileList: string[],
+  docs: { name: string; content: string }[] = [],
+  level = 0.5
+): Promise<RoastComment[]> {
+  const fileContent = fileList.slice(0, 200).join('\n')
+  const docContent = docs
+    .slice(0, 5)
+    .map(d => `### ${d.name}\n${d.content.slice(0, 1000)}`)
+    .join('\n\n')
+  const content = docContent ? `${fileContent}\n\n${docContent}` : fileContent
   const messages: any = [
     {
       role: 'system',
-      content:
-        `Provide a concise code review from multiple departments (frontend, backend, ops) at criticism level ${level} (0=gently, 1=brutal). Respond with JSON {"reviews":[{"department":string,"comment":string,"temperature":number}]}. Temperature is between 0 and 1 indicating criticism level.`
+      content: `Provide a concise project review from frontend, backend and ops departments at criticism level ${level} (0=gently, 1=brutal). Consider the repository file list and accompanying documentation. Respond with JSON {\"reviews\":[{\"department\":string,\"comment\":string,\"temperature\":number}]}. Temperature is between 0 and 1 indicating criticism level.`
     },
     { role: 'user', content }
   ]


### PR DESCRIPTION
## Summary
- include uploaded docs when running Roaster and show v0.1.7 in the UI
- update roaster API and OpenAI helper to process docs alongside repo files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a822696b788322922f29fe874451a3