### PR TITLE
feat: add GitHub app OAuth support for private repos

### DIFF
--- a/app/api/code/[...name]/route.ts
+++ b/app/api/code/[...name]/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { spawn } from 'child_process'
 import AdmZip from 'adm-zip'
+import { githubHeaders } from '../../../../lib/github'
 
 export async function GET(
   req: NextRequest,
@@ -21,7 +22,7 @@ export async function GET(
   if (repo) {
     try {
       const url = `https://codeload.github.com/${repo}/zip/${branch}`
-      const res = await fetch(url)
+      const res = await fetch(url, { headers: githubHeaders(req) })
       if (res.ok) {
         const buffer = Buffer.from(await res.arrayBuffer())
         const zip = new AdmZip(buffer)

--- a/app/api/components/route.ts
+++ b/app/api/components/route.ts
@@ -1,7 +1,8 @@
 // @ts-nocheck
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
 import pkg from '../../../package.json';
 import AdmZip from 'adm-zip';
+import { githubHeaders } from '../../../lib/github'
 
 type Row = {
   name: string;
@@ -38,7 +39,7 @@ function scores(name: string) {
   return { impact, security, ops, health, coupling, upgrade };
 }
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url)
   const repo = searchParams.get('repo')
   const branch = searchParams.get('branch') || 'main'
@@ -47,7 +48,7 @@ export async function GET(req: Request) {
   if (repo) {
     try {
       const url = `https://codeload.github.com/${repo}/zip/${branch}`
-      const res = await fetch(url)
+      const res = await fetch(url, { headers: githubHeaders(req) })
       if (res.ok) {
         const buffer = Buffer.from(await res.arrayBuffer())
         const zip = new AdmZip(buffer)

--- a/app/api/github/auth/route.ts
+++ b/app/api/github/auth/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const clientId = process.env.GITHUB_CLIENT_ID
+  if (!clientId) {
+    return NextResponse.json({ error: 'GITHUB_CLIENT_ID not set' }, { status: 500 })
+  }
+  const redirectUri = `${req.nextUrl.origin}/api/github/callback`
+  const url = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=repo`
+  return NextResponse.redirect(url)
+}

--- a/app/api/github/branches/route.ts
+++ b/app/api/github/branches/route.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { NextRequest, NextResponse } from 'next/server'
 import { jitterOffsets } from '../../../../lib/openai'
+import { githubHeaders } from '../../../../lib/github'
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -9,7 +10,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'repo required' }, { status: 400 });
   }
   const res = await fetch(`https://api.github.com/repos/${repo}/branches`, {
-    headers: { Accept: 'application/vnd.github+json' }
+    headers: githubHeaders(req)
   })
   if (!res.ok) {
     // Return an empty array with 200 status so the client can handle missing repos gracefully

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const code = req.nextUrl.searchParams.get('code')
+  if (!code) {
+    return NextResponse.json({ error: 'code required' }, { status: 400 })
+  }
+  const clientId = process.env.GITHUB_CLIENT_ID
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET
+  if (!clientId || !clientSecret) {
+    return NextResponse.json({ error: 'missing oauth env vars' }, { status: 500 })
+  }
+  const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+    body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code })
+  })
+  const data = await tokenRes.json()
+  if (!tokenRes.ok || !data.access_token) {
+    return NextResponse.json({ error: 'oauth exchange failed' }, { status: 500 })
+  }
+  const res = NextResponse.redirect('/')
+  res.cookies.set('github_token', data.access_token, { httpOnly: true, secure: true, path: '/' })
+  return res
+}

--- a/app/api/github/commit/route.ts
+++ b/app/api/github/commit/route.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { NextRequest, NextResponse } from 'next/server'
+import { githubHeaders } from '../../../../lib/github'
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url)
@@ -9,7 +10,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'repo and sha required' }, { status: 400 })
   }
   const res = await fetch(`https://api.github.com/repos/${repo}/commits/${sha}`, {
-    headers: { Accept: 'application/vnd.github+json' }
+    headers: githubHeaders(req)
   })
   if (!res.ok) {
     return NextResponse.json({ error: 'github fetch failed' }, { status: res.status })

--- a/app/api/github/commits/route.ts
+++ b/app/api/github/commits/route.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { NextRequest, NextResponse } from 'next/server'
 import { categorizeCommits, jitterOffsets } from '../../../../lib/openai'
+import { githubHeaders } from '../../../../lib/github'
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url)
@@ -12,7 +13,7 @@ export async function GET(req: NextRequest) {
 
   const commitsRes = await fetch(
     `https://api.github.com/repos/${repo}/commits?sha=${branch}`,
-    { headers: { Accept: 'application/vnd.github+json' } }
+    { headers: githubHeaders(req) }
   )
   if (!commitsRes.ok) {
     return NextResponse.json({ error: 'github fetch failed' }, { status: commitsRes.status })
@@ -27,10 +28,10 @@ export async function GET(req: NextRequest) {
       try {
         const [statusRes, detailRes] = await Promise.all([
           fetch(`https://api.github.com/repos/${repo}/commits/${c.sha}/status`, {
-            headers: { Accept: 'application/vnd.github+json' }
+            headers: githubHeaders(req)
           }).catch(() => null),
           fetch(`https://api.github.com/repos/${repo}/commits/${c.sha}`, {
-            headers: { Accept: 'application/vnd.github+json' }
+            headers: githubHeaders(req)
           })
         ])
         if (statusRes && statusRes.ok) {

--- a/app/api/github/contents/route.ts
+++ b/app/api/github/contents/route.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { NextRequest, NextResponse } from 'next/server';
+import { githubHeaders } from '../../../../lib/github'
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -12,7 +13,7 @@ export async function GET(req: NextRequest) {
 
   const res = await fetch(
     `https://api.github.com/repos/${repo}/contents/${path}?ref=${branch}`,
-    { headers: { Accept: 'application/vnd.github+json' } }
+    { headers: githubHeaders(req) }
   );
   if (!res.ok) {
     return NextResponse.json({ error: 'github fetch failed' }, { status: res.status });

--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
+
+function verifySignature(req: NextRequest, payload: string) {
+  const secret = process.env.GITHUB_WEBHOOK_SECRET
+  if (!secret) return true
+  const signature = req.headers.get('x-hub-signature-256')
+  if (!signature) return false
+  const hmac = crypto.createHmac('sha256', secret)
+  hmac.update(payload)
+  const digest = `sha256=${hmac.digest('hex')}`
+  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(digest))
+}
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text()
+  if (!verifySignature(req, payload)) {
+    return NextResponse.json({ error: 'invalid signature' }, { status: 401 })
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/ingest/route.ts
+++ b/app/api/ingest/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import AdmZip from 'adm-zip'
 import { summarizeRepo } from '../../../lib/openai'
+import { githubHeaders } from '../../../lib/github'
 
 export async function POST(req: NextRequest) {
   const form = await req.formData()
@@ -11,7 +12,7 @@ export async function POST(req: NextRequest) {
 
   if (typeof repo === 'string' && repo) {
     const url = `https://codeload.github.com/${repo}/zip/${branch}`
-    const res = await fetch(url)
+    const res = await fetch(url, { headers: githubHeaders(req) })
     if (!res.ok) {
       return NextResponse.json({ error: 'failed to fetch repo' }, { status: 500 })
     }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server'
+
+export function githubHeaders(req: NextRequest): HeadersInit {
+  const headers: HeadersInit = { Accept: 'application/vnd.github+json' }
+  const token =
+    req.headers.get('x-github-token') ||
+    req.cookies.get('github_token')?.value ||
+    process.env.GITHUB_TOKEN
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+  return headers
+}

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,27 @@ The home page now links to key interfaces:
 
 *Binary assets such as `.ico` files are intentionally excluded.*
 
+## GitHub App Integration
+
+To analyze private repositories, authorize the app with GitHub.
+
+1. Create a new GitHub App at <https://github.com/settings/apps/new> with the following settings:
+   - **Homepage URL:** `http://localhost:3000`
+   - **Callback URL:** `http://localhost:3000/api/github/callback`
+   - **Webhook URL:** `http://localhost:3000/api/github/webhook`
+   - **Repository permissions:** Contents – Read‑only, Metadata – Read‑only
+   - **Event subscriptions:** Push (optional)
+2. Install the app on the repositories you want to analyze.
+3. Add environment variables to `.env.local`:
+
+   ```bash
+   GITHUB_CLIENT_ID=your_client_id
+   GITHUB_CLIENT_SECRET=your_client_secret
+   GITHUB_WEBHOOK_SECRET=your_webhook_secret
+   ```
+
+4. Start the dev server and visit `http://localhost:3000/api/github/auth` to connect your GitHub account. An OAuth token with `repo` scope will be stored in a cookie and used for subsequent API calls, enabling access to private repositories.
+
 ## Integration Matrix
 
 The `/matrix` page inspects this project's `package.json` to list real dependencies.


### PR DESCRIPTION
## Summary
- add helper and headers for authenticated GitHub API requests
- support GitHub OAuth flow and webhook handling
- document GitHub App setup for private repo access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a84d0c9b1883229954721c73c3575b