### PR TITLE
Add GitHub auth controls and analysis reset

### DIFF
--- a/app/api/github/logout/route.ts
+++ b/app/api/github/logout/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const res = NextResponse.redirect('/')
+  res.cookies.set('github_token', '', {
+    httpOnly: true,
+    secure: true,
+    path: '/',
+    maxAge: 0
+  })
+  return res
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@
 import './globals.css';
 import { ReactNode } from 'react';
 import Link from 'next/link';
+import { cookies } from 'next/headers';
+import AuthControls from '../components/AuthControls';
 
 
 export const metadata = {
@@ -12,6 +14,7 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const isLoggedIn = cookies().has('github_token');
   return (
     <html lang="en">
       <body className="min-h-screen bg-black text-zinc-200">
@@ -38,6 +41,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <Link href="/3d-map" className="hover:text-emerald-400">
               3D Map
             </Link>
+            <AuthControls isLoggedIn={isLoggedIn} />
           </nav>
         </header>
         {children}

--- a/components/AuthControls.tsx
+++ b/components/AuthControls.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { useCallback } from 'react'
+
+export default function AuthControls({ isLoggedIn }: { isLoggedIn: boolean }) {
+  const handleReset = useCallback(() => {
+    if (confirm('Reset all analysis results?')) {
+      localStorage.clear()
+      location.reload()
+    }
+  }, [])
+
+  return (
+    <div className="ml-auto flex items-center gap-4">
+      <button onClick={handleReset} className="hover:text-emerald-400">Reset</button>
+      {isLoggedIn ? (
+        <a href="/api/github/logout" className="hover:text-emerald-400">Logout</a>
+      ) : (
+        <a href="/api/github/auth" className="hover:text-emerald-400">Login</a>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add login/logout and reset controls to nav bar
- add API route to clear GitHub auth cookie

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8535af2f883228e805e961f8ceb64