### PR TITLE
Add GitHub auth controls and split ingest flows

### DIFF
--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -1,25 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(req: NextRequest) {
+  const error = req.nextUrl.searchParams.get('error')
+  if (error) {
+    return NextResponse.redirect(new URL(`/?error=${error}`, req.url))
+  }
   const code = req.nextUrl.searchParams.get('code')
   if (!code) {
-    return NextResponse.json({ error: 'code required' }, { status: 400 })
+    return NextResponse.redirect(new URL('/?error=code', req.url))
   }
   const clientId = process.env.GITHUB_CLIENT_ID
   const clientSecret = process.env.GITHUB_CLIENT_SECRET
   if (!clientId || !clientSecret) {
-    return NextResponse.json({ error: 'missing oauth env vars' }, { status: 500 })
+    return NextResponse.redirect(new URL('/?error=config', req.url))
   }
   const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
     method: 'POST',
-    headers: { Accept: 'application/json' },
-    body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code })
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code
+    })
   })
   const data = await tokenRes.json()
   if (!tokenRes.ok || !data.access_token) {
-    return NextResponse.json({ error: 'oauth exchange failed' }, { status: 500 })
+    return NextResponse.redirect(new URL('/?error=oauth', req.url))
   }
-  const res = NextResponse.redirect('/')
+  const res = NextResponse.redirect(new URL('/', req.url))
   res.cookies.set('github_token', data.access_token, { httpOnly: true, secure: true, path: '/' })
   return res
 }

--- a/app/api/github/logout/route.ts
+++ b/app/api/github/logout/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const res = NextResponse.redirect(new URL('/', req.url))
+  res.cookies.set('github_token', '', {
+    httpOnly: true,
+    secure: true,
+    path: '/',
+    maxAge: 0
+  })
+  return res
+}

--- a/app/ingest/page.tsx
+++ b/app/ingest/page.tsx
@@ -199,22 +199,44 @@ export default function IngestPage() {
         <div className="absolute inset-0 bg-black/60" />
       </div>
       <div className="relative z-10 p-10 space-y-6">
-        <h1 className="text-2xl font-semibold tracking-tight">Manual Ingest</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">Ingest</h1>
         <div className="flex flex-col md:flex-row md:gap-8">
           <div className="space-y-8 max-w-md">
             <section className="space-y-4">
-              <h2 className="text-lg font-medium">Supporting Documents</h2>
-              <input
-                type="file"
-                multiple
-                accept=".pdf,.docx,.xlsx,.csv"
-                onChange={onDocsChange}
-                className="block w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-zinc-800 file:text-zinc-200 hover:file:bg-zinc-700"
-              />
-              <p className="text-xs text-zinc-400">{docs.length}/5 files selected</p>
+              <h2 className="text-lg font-medium">Manual Ingest</h2>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <h3 className="text-sm font-medium">Supporting Documents</h3>
+                  <input
+                    type="file"
+                    multiple
+                    accept=".pdf,.docx,.xlsx,.csv"
+                    onChange={onDocsChange}
+                    className="block w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-zinc-800 file:text-zinc-200 hover:file:bg-zinc-700"
+                  />
+                  <p className="text-xs text-zinc-400">{docs.length}/5 files selected</p>
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-sm font-medium">Manual ZIP Upload</h3>
+                  <form onSubmit={onSubmit} className="space-y-4">
+                    <input
+                      type="file"
+                      name="file"
+                      accept=".zip"
+                      className="block w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-zinc-800 file:text-zinc-200 hover:file:bg-zinc-700"
+                    />
+                    <button
+                      type="submit"
+                      className="px-4 py-2 bg-emerald-600 text-sm font-medium rounded-lg hover:bg-emerald-500 transition"
+                    >
+                      Upload and Analyze
+                    </button>
+                  </form>
+                </div>
+              </div>
             </section>
             <section className="space-y-4">
-              <h2 className="text-lg font-medium">GitHub Repository</h2>
+              <h2 className="text-lg font-medium">GitHub Ingest</h2>
               <div className="flex gap-2">
                 <input
                   value={repo}
@@ -238,7 +260,9 @@ export default function IngestPage() {
                 >
                   <option value="">select branch</option>
                   {branches.map(b => (
-                    <option key={b} value={b}>{b}</option>
+                    <option key={b} value={b}>
+                      {b}
+                    </option>
                   ))}
                 </select>
               )}
@@ -249,23 +273,6 @@ export default function IngestPage() {
               >
                 Analyze Repo
               </button>
-            </section>
-            <section className="space-y-4">
-              <h2 className="text-lg font-medium">Manual ZIP Upload</h2>
-              <form onSubmit={onSubmit} className="space-y-4">
-                <input
-                  type="file"
-                  name="file"
-                  accept=".zip"
-                  className="block w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-zinc-800 file:text-zinc-200 hover:file:bg-zinc-700"
-                />
-                <button
-                  type="submit"
-                  className="px-4 py-2 bg-emerald-600 text-sm font-medium rounded-lg hover:bg-emerald-500 transition"
-                >
-                  Upload and Analyze
-                </button>
-              </form>
             </section>
           </div>
           <div className="flex-none w-[560px] ml-auto mr-4">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@
 import './globals.css';
 import { ReactNode } from 'react';
 import Link from 'next/link';
+import { cookies } from 'next/headers';
+import AuthControls from '../components/AuthControls';
 
 
 export const metadata = {
@@ -12,6 +14,7 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const isLoggedIn = cookies().has('github_token');
   return (
     <html lang="en">
       <body className="min-h-screen bg-black text-zinc-200">
@@ -38,6 +41,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <Link href="/3d-map" className="hover:text-emerald-400">
               3D Map
             </Link>
+            <AuthControls isLoggedIn={isLoggedIn} />
           </nav>
         </header>
         {children}

--- a/components/AuthControls.tsx
+++ b/components/AuthControls.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { useCallback } from 'react'
+
+export default function AuthControls({ isLoggedIn }: { isLoggedIn: boolean }) {
+  const handleReset = useCallback(() => {
+    if (confirm('Reset all analysis results?')) {
+      localStorage.clear()
+      location.reload()
+    }
+  }, [])
+
+  return (
+    <div className="ml-auto flex items-center gap-4">
+      <button onClick={handleReset} className="hover:text-emerald-400">Reset</button>
+      {isLoggedIn ? (
+        <a href="/api/github/logout" className="hover:text-emerald-400">Logout</a>
+      ) : (
+        <a href="/api/github/auth" className="hover:text-emerald-400">Login</a>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- ensure auth control renders correctly with client directive
- separate manual uploads from GitHub API ingestion on ingest page
- fix logout route to redirect using absolute URL so build succeeds
- resolve GitHub OAuth callback failure by form-encoding token exchange and redirecting on error

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8535af2f883228e805e961f8ceb64