### PR TITLE
feat: enhance github ingest and roaster

### DIFF
--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import { NextRequest, NextResponse } from 'next/server'
+import { githubHeaders } from '../../../../lib/github'
+
+export async function GET(req: NextRequest) {
+  try {
+    const res = await fetch('https://api.github.com/user/repos', {
+      headers: githubHeaders(req)
+    })
+    if (!res.ok) {
+      return NextResponse.json([])
+    }
+    const data = await res.json()
+    const repos = Array.isArray(data) ? data.map((r: any) => ({ name: r.full_name })) : []
+    return NextResponse.json(repos)
+  } catch {
+    return NextResponse.json([])
+  }
+}

--- a/app/api/ingest/route.ts
+++ b/app/api/ingest/route.ts
@@ -65,7 +65,7 @@ export async function POST(req: NextRequest) {
       branch,
       files,
       code,
-      docs: docs.map(d => ({ name: d.name, type: d.type })),
+      docs,
       analysis
     })
   } catch (err) {

--- a/app/api/roaster/route.ts
+++ b/app/api/roaster/route.ts
@@ -4,8 +4,12 @@ import { roastRepo } from '../../../lib/openai'
 
 export async function POST(req: Request) {
   try {
-    const { files, level = 0.5 } = await req.json()
-    const comments = await roastRepo(Array.isArray(files) ? files : [], level)
+    const { files, docs = [], level = 0.5 } = await req.json()
+    const comments = await roastRepo(
+      Array.isArray(files) ? files : [],
+      Array.isArray(docs) ? docs : [],
+      level
+    )
     return NextResponse.json({ comments })
   } catch (err: any) {
     return NextResponse.json({ error: err?.message || 'roaster failed' }, { status: 500 })

--- a/app/ingest/page.tsx
+++ b/app/ingest/page.tsx
@@ -17,6 +17,7 @@ type Result = {
   files: string[]
   analysis: RepoAnalysis
   code?: any[]
+  docs: { name: string; type: string; content: string }[]
 }
 
 function Card({ children }: { children: React.ReactNode }) {
@@ -67,6 +68,7 @@ export default function IngestPage() {
   // hide console by default; users can reveal as needed
   const [showConsole, setShowConsole] = useState(false)
   const [repo, setRepo] = useState('')
+  const [repos, setRepos] = useState<string[]>([])
   const [branches, setBranches] = useState<string[]>([])
   const [branch, setBranch] = useState('')
   const [error, setError] = useState('')
@@ -155,15 +157,21 @@ export default function IngestPage() {
     }
   }
 
-  async function loadBranches() {
-    if (!repo) return
-    const res = await fetch(`/api/github/branches?repo=${repo}`)
+  async function loadBranches(selectedRepo: string) {
+    if (!selectedRepo) return
+    const res = await fetch(`/api/github/branches?repo=${selectedRepo}`)
     const data = await (res.ok ? res.json() : Promise.resolve([]))
     if (Array.isArray(data)) {
       setBranches(data.map((d: any) => d.name))
     } else {
       setBranches([])
     }
+  }
+
+  function handleRepoChange(value: string) {
+    setRepo(value)
+    setBranch('')
+    loadBranches(value)
   }
 
   async function analyzeRepo() {
@@ -201,6 +209,19 @@ export default function IngestPage() {
     setDocs(newDocs)
     setDocsState(newDocs)
   }
+
+  useEffect(() => {
+    async function loadRepos() {
+      const res = await fetch('/api/github/repos')
+      const data = await (res.ok ? res.json() : [])
+      if (Array.isArray(data)) {
+        setRepos(data.map((r: any) => r.name))
+      } else {
+        setRepos([])
+      }
+    }
+    if (mode === 'github') loadRepos()
+  }, [mode])
 
 
   return (
@@ -263,34 +284,39 @@ export default function IngestPage() {
             {mode === 'github' && (
               <section className="space-y-4">
                 <h2 className="text-lg font-medium">GitHub Ingest</h2>
-                <div className="flex gap-2">
-                  <input
-                    value={repo}
-                    onChange={e => setRepo(e.target.value)}
-                    placeholder="owner/repo"
-                    className="flex-1 px-3 py-2 rounded bg-zinc-900 border border-zinc-800 text-sm"
-                  />
-                  <button
-                    type="button"
-                    onClick={loadBranches}
-                    className="px-3 py-2 bg-zinc-800 rounded text-xs"
-                  >
-                    Load
-                  </button>
-                </div>
-                {branches.length > 0 && (
-                  <select
-                    value={branch}
-                    onChange={e => setBranch(e.target.value)}
-                    className="w-full px-3 py-2 rounded bg-zinc-900 border border-zinc-800 text-sm"
-                  >
-                    <option value="">select branch</option>
-                    {branches.map(b => (
-                      <option key={b} value={b}>
-                        {b}
-                      </option>
-                    ))}
-                  </select>
+                {repos.length > 0 ? (
+                  <div className="space-y-2">
+                    <select
+                      value={repo}
+                      onChange={e => handleRepoChange(e.target.value)}
+                      className="w-full px-3 py-2 rounded-lg bg-zinc-900 border border-zinc-800 text-sm"
+                    >
+                      <option value="">select repo</option>
+                      {repos.map(r => (
+                        <option key={r} value={r}>
+                          {r}
+                        </option>
+                      ))}
+                    </select>
+                    {branches.length > 0 && (
+                      <select
+                        value={branch}
+                        onChange={e => setBranch(e.target.value)}
+                        className="w-full px-3 py-2 rounded-lg bg-zinc-900 border border-zinc-800 text-sm"
+                      >
+                        <option value="">select branch</option>
+                        {branches.map(b => (
+                          <option key={b} value={b}>
+                            {b}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-xs text-zinc-400">
+                    Login with GitHub to list repos.
+                  </p>
                 )}
                 <button
                   type="button"

--- a/app/roaster/page.tsx
+++ b/app/roaster/page.tsx
@@ -6,7 +6,7 @@ import HexBackground from '../../components/HexBackground'
 import { getRoasterState, setRoasterState } from '../../lib/roasterState'
 import { getOintData } from '../../lib/toolsetState'
 
-type Result = { files: string[] }
+type Result = { files: string[]; docs: { name: string; type: string; content: string }[] }
 type Comment = { department: string; comment: string; temperature: number }
 
 const departments = ['frontend', 'backend', 'ops'] as const
@@ -301,7 +301,7 @@ export default function RoasterPage() {
       const res = await fetch('/api/roaster', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ files: result.files, level })
+        body: JSON.stringify({ files: result.files, docs: result.docs, level })
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'roaster failed')
@@ -392,7 +392,7 @@ export default function RoasterPage() {
         <div className="flex items-start justify-between">
           <h1 className="text-2xl font-semibold tracking-tight">Roaster</h1>
           <div className="text-right leading-tight">
-            <div className="text-5xl font-bold">Roaster v0.1.6</div>
+            <div className="text-5xl font-bold">Roaster v0.1.8</div>
             <div className="text-sm text-zinc-400">AI-powered code critique, assisting in project management</div>
           </div>
         </div>

--- a/components/AuthControls.tsx
+++ b/components/AuthControls.tsx
@@ -1,5 +1,6 @@
-'use client';
+'use client'
 import { useCallback } from 'react'
+import { Github } from 'lucide-react'
 
 export default function AuthControls({ isLoggedIn }: { isLoggedIn: boolean }) {
   const handleReset = useCallback(() => {
@@ -11,11 +12,23 @@ export default function AuthControls({ isLoggedIn }: { isLoggedIn: boolean }) {
 
   return (
     <div className="ml-auto flex items-center gap-4">
-      <button onClick={handleReset} className="hover:text-emerald-400">Reset</button>
+      <button onClick={handleReset} className="hover:text-emerald-400">
+        Reset
+      </button>
       {isLoggedIn ? (
-        <a href="/api/github/logout" className="hover:text-emerald-400">Logout</a>
+        <a
+          href="/api/github/logout"
+          className="hover:text-emerald-400 flex items-center gap-1"
+        >
+          <Github className="w-4 h-4" /> Logout
+        </a>
       ) : (
-        <a href="/api/github/auth" className="hover:text-emerald-400">Login</a>
+        <a
+          href="/api/github/auth"
+          className="hover:text-emerald-400 flex items-center gap-1"
+        >
+          <Github className="w-4 h-4" /> Login
+        </a>
       )}
     </div>
   )

--- a/components/DocsUploader.tsx
+++ b/components/DocsUploader.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useState } from 'react'
 import type { DocItem } from '../lib/docsState'
 
 const SLOT_LABELS = [
@@ -16,6 +17,7 @@ export default function DocsUploader({
   docs: (DocItem | null)[]
   setDocs: (d: (DocItem | null)[]) => void
 }) {
+  const [open, setOpen] = useState(true)
   function handleFile(idx: number, file: File) {
     const next = [...docs]
     next[idx] = { file, name: file.name, type: SLOT_LABELS[idx].type }
@@ -36,13 +38,23 @@ export default function DocsUploader({
 
   return (
     <div className="space-y-4">
-      <h2 className="text-lg font-medium">Supporting Documents</h2>
-      <div className="grid gap-4">
-        {SLOT_LABELS.map((slot, idx) => {
-          const item = docs[idx]
-          return (
-            <div
-              key={idx}
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-medium">Supporting Documents</h2>
+        <button
+          type="button"
+          onClick={() => setOpen(o => !o)}
+          className="text-xs text-emerald-400"
+        >
+          {open ? 'Hide' : 'Show'}
+        </button>
+      </div>
+      {open && (
+        <div className="grid gap-4">
+          {SLOT_LABELS.map((slot, idx) => {
+            const item = docs[idx]
+            return (
+              <div
+                key={idx}
               className="p-4 border border-zinc-800 rounded-lg bg-zinc-900/40"
             >
               {item ? (
@@ -76,7 +88,8 @@ export default function DocsUploader({
             </div>
           )
         })}
-      </div>
+        </div>
+      )}
       <p className="text-xs text-zinc-400">
         {docs.filter(Boolean).length}/5 files uploaded
       </p>

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -79,13 +79,21 @@ export async function summarizeRepo(
   return JSON.parse(txt)
 }
 
-export async function roastRepo(fileList: string[], level = 0.5): Promise<RoastComment[]> {
-  const content = fileList.slice(0, 200).join('\n')
+export async function roastRepo(
+  fileList: string[],
+  docs: { name: string; type: string; content: string }[] = [],
+  level = 0.5
+): Promise<RoastComment[]> {
+  const filesPart = fileList.slice(0, 200).join('\n')
+  const docsPart = docs
+    .map(d => `${d.type.toUpperCase()} (${d.name}):\n${d.content}`)
+    .join('\n---\n')
+  const content = `FILES:\n${filesPart}\nDOCS:\n${docsPart}`
   const messages: any = [
     {
       role: 'system',
       content:
-        `Provide a concise code review from multiple departments (frontend, backend, ops) at criticism level ${level} (0=gently, 1=brutal). Respond with JSON {"reviews":[{"department":string,"comment":string,"temperature":number}]}. Temperature is between 0 and 1 indicating criticism level.`
+        `Provide a concise code review from multiple departments (frontend, backend, ops) at criticism level ${level} (0=gently, 1=brutal). Consider supporting documents like PRDs or estimates and highlight any deviations from documented requirements or timelines. Respond with JSON {"reviews":[{"department":string,"comment":string,"temperature":number}]}. Temperature is between 0 and 1 indicating criticism level.`
     },
     { role: 'user', content }
   ]


### PR DESCRIPTION
## Summary
- add GitHub icons to login/logout links
- make supporting document uploader collapsible
- support selecting authorized GitHub repos and branches for ingest
- upgrade roaster to v0.1.8 using repo and document data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a868ffc5d0832283a66f51cbbc5cc0