### PR TITLE
Improve GitHub ingest UX and model fallback logging

### DIFF
--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -7,13 +7,16 @@ export async function GET(req: NextRequest) {
     const res = await fetch('https://api.github.com/user/repos', {
       headers: githubHeaders(req)
     })
+    if (res.status === 401) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+    }
     if (!res.ok) {
-      return NextResponse.json([])
+      return NextResponse.json({ error: 'failed' }, { status: res.status })
     }
     const data = await res.json()
     const repos = Array.isArray(data) ? data.map((r: any) => ({ name: r.full_name })) : []
     return NextResponse.json(repos)
   } catch {
-    return NextResponse.json([])
+    return NextResponse.json({ error: 'failed' }, { status: 500 })
   }
 }

--- a/app/ingest/page.tsx
+++ b/app/ingest/page.tsx
@@ -70,6 +70,7 @@ export default function IngestPage() {
   const [showConsole, setShowConsole] = useState(false)
   const [repo, setRepo] = useState('')
   const [repos, setRepos] = useState<string[]>([])
+  const [reposError, setReposError] = useState('')
   const [branches, setBranches] = useState<string[]>([])
   const [branch, setBranch] = useState('')
   const [error, setError] = useState('')
@@ -222,13 +223,21 @@ export default function IngestPage() {
     }
     async function loadRepos() {
       const res = await fetch('/api/github/repos')
+      if (res.status === 401) {
+        setRepos([])
+        setReposError('unauthorized')
+        localStorage.removeItem('repos')
+        return
+      }
       const data = await (res.ok ? res.json() : [])
       if (Array.isArray(data)) {
         const names = data.map((r: any) => r.name)
         setRepos(names)
+        setReposError('')
         localStorage.setItem('repos', JSON.stringify(names))
       } else {
         setRepos([])
+        setReposError('failed')
         localStorage.removeItem('repos')
       }
     }
@@ -327,7 +336,9 @@ export default function IngestPage() {
                   </div>
                 ) : (
                   <p className="text-xs text-zinc-400">
-                    Login with GitHub to list repos.
+                    {reposError === 'unauthorized'
+                      ? 'Login with GitHub to list repos.'
+                      : 'No repositories found.'}
                   </p>
                 )}
                 <button

--- a/app/roaster/page.tsx
+++ b/app/roaster/page.tsx
@@ -412,14 +412,14 @@ export default function RoasterPage() {
           <div className="flex flex-col gap-2">
             <div className="text-sm font-medium">Roast Temperature: {Math.round(level * 100)}%</div>
             <div className="text-xs text-zinc-400">Higher heat yields harsher criticism.</div>
-            <div className="flex gap-2">
-              <button
-                onClick={runRoaster}
-                className="px-4 py-2 bg-red-600 text-sm font-medium rounded-lg hover:bg-red-500 transition"
-              >
-                Roast!
-              </button>
-              <div className="flex flex-col items-start">
+            <div className="flex flex-col items-start gap-1">
+              <div className="flex gap-2">
+                <button
+                  onClick={runRoaster}
+                  className="px-4 py-2 bg-red-600 text-sm font-medium rounded-lg hover:bg-red-500 transition"
+                >
+                  Roast!
+                </button>
                 <button
                   onClick={applyOint}
                   disabled={!ointCreated || !roast}
@@ -429,10 +429,10 @@ export default function RoasterPage() {
                 >
                   Apply OINT
                 </button>
-                <Link href="/toolset" className="text-xs text-zinc-400 underline mt-1">
-                  Create OINT
-                </Link>
               </div>
+              <Link href="/toolset" className="text-xs text-zinc-400 underline">
+                Create OINT
+              </Link>
             </div>
           </div>
           <div className="p-4 rounded-xl bg-zinc-900/60 border border-zinc-800 flex items-center gap-4">

--- a/readme.md
+++ b/readme.md
@@ -54,9 +54,9 @@ of integration categories.
 Upload a repository ZIP or point to a GitHub repo/branch at `/ingest` to trigger
 an analysis run. Provide an API key for language model analysis via
 `AIML_API_KEY` (uses [aimlapi.com](https://aimlapi.com) by default); analyses
-prefer the `gpt-5-nano` model with automatic fallback to `gpt-4o` for
-stability. Upload & Analyse, Roaster, and Vibe Killer all run on `gpt-5-nano`,
-while OINT defaults to `gpt-5-nano` with a `gpt-4o` fallback. The last
+prefer the `gpt-5-chat` model with automatic fallback to `gpt-4o` for
+stability. Upload & Analyse, Roaster, and Vibe Killer all run on `gpt-5-chat`,
+while OINT defaults to `gpt-5-chat` with a `gpt-4o` fallback. The last
 ingest result along with your selected repo and branch are cached in the browser
 so you can navigate away and return without losing context. Below the console,
 AI‑extracted takeaways and metrics render in animated widgets. The OINT toolset


### PR DESCRIPTION
## Summary
- log model failures and fallbacks while preferring `gpt-5-chat`
- refine GitHub repo fetch to signal unauthorized status
- display clear repo loading messages and align Roaster controls
- document `gpt-5-chat` as default model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88bc216948322967ecfa897339e53