### PR TITLE
feat: enhance OINT analysis and repo ingest

### DIFF
--- a/app/api/components/route.ts
+++ b/app/api/components/route.ts
@@ -17,15 +17,14 @@ type Row = {
 };
 
 function categorize(name: string): string {
-  const categories: Record<string, string> = {
-    next: 'Frameworks/Libs',
-    react: 'Frameworks/Libs',
-    'react-dom': 'Frameworks/Libs',
-    openai: 'ML/AI',
-    'lucide-react': 'Frameworks/Libs',
-    'adm-zip': 'Infra & DevOps',
-  };
-  return categories[name] || 'Frameworks/Libs';
+  const n = name.toLowerCase()
+  if (/aws|azure|gcp|firebase|supabase/.test(n)) return 'Cloud'
+  if (/chart|d3|graph|plot/.test(n)) return 'Visualization'
+  if (/tailwind|bootstrap|css|sass|style|mui/.test(n)) return 'Styling'
+  if (/lint|eslint|prettier|babel|webpack|vite/.test(n)) return 'Tooling'
+  if (/zip|fs|path|express|axios|server/.test(n)) return 'Infra & DevOps'
+  if (/ai|ml|openai|tensorflow|torch/.test(n)) return 'ML/AI'
+  return 'Frameworks/Libs'
 }
 
 function scores(name: string) {

--- a/app/api/github/commits/route.ts
+++ b/app/api/github/commits/route.ts
@@ -6,7 +6,21 @@ import { githubHeaders } from '../../../../lib/github'
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url)
   const repo = searchParams.get('repo')
-  const branch = searchParams.get('branch') || 'main'
+  let branch = searchParams.get('branch') || ''
+  if (!branch && repo) {
+    try {
+      const infoRes = await fetch(`https://api.github.com/repos/${repo}`, {
+        headers: githubHeaders(req)
+      })
+      if (infoRes.ok) {
+        const info = await infoRes.json()
+        branch = info.default_branch || 'main'
+      }
+    } catch {
+      branch = 'main'
+    }
+  }
+  if (!branch) branch = 'main'
   if (!repo) {
     return NextResponse.json({ error: 'repo required' }, { status: 400 })
   }

--- a/app/api/github/contents/route.ts
+++ b/app/api/github/contents/route.ts
@@ -6,7 +6,21 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const repo = searchParams.get('repo');
   const path = searchParams.get('path') || '';
-  const branch = searchParams.get('branch') || 'main';
+  let branch = searchParams.get('branch') || '';
+  if (!branch && repo) {
+    try {
+      const infoRes = await fetch(`https://api.github.com/repos/${repo}`, {
+        headers: githubHeaders(req)
+      });
+      if (infoRes.ok) {
+        const info = await infoRes.json();
+        branch = info.default_branch || 'main';
+      }
+    } catch {
+      branch = 'main';
+    }
+  }
+  if (!branch) branch = 'main';
   if (!repo) {
     return NextResponse.json({ error: 'repo required' }, { status: 400 });
   }

--- a/app/api/ingest/route.ts
+++ b/app/api/ingest/route.ts
@@ -7,7 +7,21 @@ import { githubHeaders } from '../../../lib/github'
 export async function POST(req: NextRequest) {
   const form = await req.formData()
   const repo = form.get('repo')
-  const branch = form.get('branch') || 'main'
+  let branch = form.get('branch')?.toString() || ''
+  if (!branch && typeof repo === 'string' && repo) {
+    try {
+      const infoRes = await fetch(`https://api.github.com/repos/${repo}`, {
+        headers: githubHeaders(req)
+      })
+      if (infoRes.ok) {
+        const info = await infoRes.json()
+        branch = info.default_branch || 'main'
+      }
+    } catch {
+      branch = 'main'
+    }
+  }
+  if (!branch) branch = 'main'
   const docsMetaRaw = form.get('docs_meta')
   let docsMeta: any[] = []
   if (typeof docsMetaRaw === 'string') {

--- a/app/api/oint/apply/route.ts
+++ b/app/api/oint/apply/route.ts
@@ -11,17 +11,54 @@ export async function POST(req: Request) {
   const { docs } = getKnowledge()
   const docText = docs.map(d => d.text.toLowerCase()).join(' ')
 
-  const comments = roast.map((c: any) => ({
-    department: c.department,
-    comment: docText.includes(c.department.toLowerCase())
-      ? `Cross-check ${c.department} docs and adjust accordingly.`
-      : `Investigate ${c.department} area with limited documentation.`,
-    temperature: Math.max(0, c.temperature - 0.1)
-  }))
+  const STOP = new Set(
+    'the and for with this that from into your about there their will have has are were was its our out other such too can '.split(
+      /\s+/
+    )
+  )
+
+  function extractKeywords(text: string, dept: string) {
+    const sentences = text
+      .split(/[.!?]/)
+      .filter(s => s.includes(dept.toLowerCase()))
+    const counts = new Map<string, number>()
+    for (const s of sentences) {
+      for (const raw of s.split(/[^a-z0-9]+/)) {
+        const w = raw.trim()
+        if (!w || STOP.has(w) || w === dept.toLowerCase()) continue
+        counts.set(w, (counts.get(w) || 0) + 1)
+      }
+    }
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([w]) => w)
+  }
+
+  const comments = roast.map((c: any) => {
+    const keywords = extractKeywords(docText, c.department)
+    const comment = keywords.length
+      ? `Key topics: ${keywords.join(', ')}`
+      : `No documentation found for ${c.department}`
+    return {
+      department: c.department,
+      comment,
+      temperature: Math.max(0, c.temperature - 0.1)
+    }
+  })
 
   const docSteps = docs.map(d => `Review ${d.name}`)
+  const keywordSteps = comments.flatMap(
+    (c: { department: string; comment: string }) =>
+      c.comment.startsWith('Key topics:')
+        ? c.comment
+            .replace('Key topics: ', '')
+            .split(', ')
+            .map((k: string) => `Investigate ${c.department} ${k}`)
+        : [`Investigate ${c.department}`]
+  )
   const roastSteps = roast.map((c: any) => `Resolve ${c.department} feedback`)
-  const steps = [...docSteps, ...roastSteps].slice(0, 5)
+  const steps = Array.from(new Set([...docSteps, ...keywordSteps, ...roastSteps])).slice(0, 5)
 
   return NextResponse.json({ comments, steps })
 }

--- a/app/api/oint/create/route.ts
+++ b/app/api/oint/create/route.ts
@@ -24,18 +24,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'insufficient data for OINT' }, { status: 400 })
   }
 
-  for (const _ of repoFiles) {
-    await new Promise(r => setTimeout(r, 10))
-  }
-  for (const d of parsedDocs) {
-    await new Promise(r => setTimeout(r, Math.min(d.text.length / 50, 20)))
-  }
-
   const hasFinance = parsedDocs.some(d =>
     /fin|budget|cost|expense/i.test(d.name + d.text)
   )
 
   markCreated(parsedDocs, repoFiles, hasVuln, hasFinance)
 
-  return NextResponse.json({ status: 'created', jobId: 'analysis-job' })
+  return NextResponse.json({ status: 'created' })
 }

--- a/app/api/oint/summary/route.ts
+++ b/app/api/oint/summary/route.ts
@@ -56,27 +56,11 @@ export async function GET() {
     day: `Day ${i + 1}`,
     step: `Review ${d.name}`
   }))
-
-  const extraSteps = [
-    'Codebase orientation',
-    'Audit dependencies',
-    'Establish CI pipeline',
-    'Set up testing framework',
-    'Implement monitoring',
-    'Plan deployment strategy',
-    'Conduct security review',
-    'Optimize performance',
-    'Review team responsibilities',
-    'Finalize onboarding'
-  ]
-  let idx = 0
-  while (onboardingPlan.length < 10) {
-    onboardingPlan.push({
-      day: `Day ${onboardingPlan.length + 1}`,
-      step: extraSteps[idx % extraSteps.length]
-    })
-    idx++
-  }
+  const planFiles = files.filter(f => /\.(js|ts|jsx|tsx|py|rb|go|java|rs)$/i.test(f))
+  const remaining = 10 - onboardingPlan.length
+  planFiles.slice(0, remaining).forEach(f => {
+    onboardingPlan.push({ day: `Day ${onboardingPlan.length + 1}`, step: `Explore ${f}` })
+  })
 
   const data: DashboardData = {
     generatedAt: new Date().toISOString(),

--- a/app/ingest/page.tsx
+++ b/app/ingest/page.tsx
@@ -71,8 +71,6 @@ export default function IngestPage() {
   const [repo, setRepo] = useState('')
   const [repos, setRepos] = useState<string[]>([])
   const [reposError, setReposError] = useState('')
-  const [branches, setBranches] = useState<string[]>([])
-  const [branch, setBranch] = useState('')
   const [error, setError] = useState('')
   const [docs, setDocs] = useState<(DocItem | null)[]>(getDocsState())
   const [hasVuln, setHasVuln] = useState(false)
@@ -114,9 +112,7 @@ export default function IngestPage() {
     const stored = localStorage.getItem('ingestResult')
     if (stored) setResult(JSON.parse(stored))
     const storedRepo = localStorage.getItem('repo')
-    const storedBranch = localStorage.getItem('branch')
     if (storedRepo) setRepo(storedRepo)
-    if (storedBranch) setBranch(storedBranch)
     const storedLocal = localStorage.getItem('localRepo')
     if (storedLocal) setLocalRepo(storedLocal)
   }, [])
@@ -124,9 +120,6 @@ export default function IngestPage() {
   useEffect(() => {
     if (repo) localStorage.setItem('repo', repo)
   }, [repo])
-  useEffect(() => {
-    if (branch) localStorage.setItem('branch', branch)
-  }, [branch])
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -151,7 +144,6 @@ export default function IngestPage() {
       localStorage.setItem('ingestResult', JSON.stringify(data))
       localStorage.setItem('localRepo', file.name)
       if (repo) localStorage.setItem('repo', repo)
-      if (branch) localStorage.setItem('branch', branch)
       if (repo) prefetchTracking(repo)
 
       setError('')
@@ -173,28 +165,14 @@ export default function IngestPage() {
     setOintData(null)
   }
 
-  async function loadBranches(selectedRepo: string) {
-    if (!selectedRepo) return
-    const res = await fetch(`/api/github/branches?repo=${selectedRepo}`)
-    const data = await (res.ok ? res.json() : Promise.resolve([]))
-    if (Array.isArray(data)) {
-      setBranches(data.map((d: any) => d.name))
-    } else {
-      setBranches([])
-    }
-  }
-
   function handleRepoChange(value: string) {
     setRepo(value)
-    setBranch('')
-    loadBranches(value)
   }
 
   async function analyzeRepo() {
-    if (!repo || !branch) return
+    if (!repo) return
     const form = new FormData()
     form.append('repo', repo)
-    form.append('branch', branch)
     const docItems = docs.filter(Boolean) as DocItem[]
     docItems.forEach(d =>
       form.append('docs', new File([d.file], d.name, { type: d.file.type }))
@@ -340,20 +318,6 @@ export default function IngestPage() {
                         </option>
                       ))}
                     </select>
-                    {branches.length > 0 && (
-                      <select
-                        value={branch}
-                        onChange={e => setBranch(e.target.value)}
-                        className="w-full px-3 py-2 rounded-lg bg-zinc-900 border border-zinc-800 text-sm"
-                      >
-                        <option value="">select branch</option>
-                        {branches.map(b => (
-                          <option key={b} value={b}>
-                            {b}
-                          </option>
-                        ))}
-                      </select>
-                    )}
                   </div>
                 ) : (
                   <p className="text-xs text-zinc-400">

--- a/app/matrix/page.tsx
+++ b/app/matrix/page.tsx
@@ -6,10 +6,18 @@ import Image from 'next/image'
 import dynamic from 'next/dynamic'
 import { ArrowUpDown, Search, ShieldAlert, Cpu } from 'lucide-react'
 import HexBackground from '../../components/HexBackground'
-import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js'
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend
+} from 'chart.js'
 
-ChartJS.register(ArcElement, Tooltip, Legend)
-const Pie = dynamic(() => import('react-chartjs-2').then(m => m.Pie), { ssr: false })
+ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend)
+const Radar = dynamic(() => import('react-chartjs-2').then(m => m.Radar), { ssr: false })
 
 // Minimal shadcn pieces (replace with imported components in real app)
 function Card({children}:{children:React.ReactNode}){return <div className="rounded-2xl bg-zinc-900/60 border border-zinc-800 shadow-xl p-4 backdrop-blur-sm">{children}</div>}
@@ -182,14 +190,18 @@ export default function MatrixPage(){
   },[rows])
   const riskyAll = useMemo(()=>rows.filter(r=>r.security<60).sort((a,b)=>a.security-b.security),[rows])
   const risky = useMemo(()=>riskyAll.slice(0,2),[riskyAll])
-  const pieData = useMemo(
+  const radarData = useMemo(
     () => ({
       labels: Object.keys(categoryCounts),
       datasets: [
         {
+          label: 'Categories',
           data: Object.values(categoryCounts),
-          backgroundColor: ['#10b981', '#3b82f6', '#a855f7', '#f59e0b', '#ef4444', '#f472b6'],
-          borderColor: 'transparent'
+          backgroundColor: 'rgba(16,185,129,0.3)',
+          borderColor: '#10b981',
+          pointBackgroundColor: '#10b981',
+          pointBorderColor: '#10b981',
+          fill: true
         }
       ]
     }),
@@ -300,9 +312,22 @@ export default function MatrixPage(){
             </div>
           </ExpandableCard>
           <Card>
-            <div className="text-sm font-semibold mb-2">Category Breakdown</div>
+            <div className="text-sm font-semibold mb-2">Category Radar</div>
             {Object.keys(categoryCounts).length > 0 ? (
-              <Pie data={pieData} options={{ plugins: { legend: { display: false } } }} />
+              <Radar
+                data={radarData}
+                options={{
+                  plugins: { legend: { display: false } },
+                  scales: {
+                    r: {
+                      beginAtZero: true,
+                      angleLines: { color: '#27272a' },
+                      grid: { color: '#27272a' },
+                      ticks: { display: false }
+                    }
+                  }
+                }}
+              />
             ) : (
               <div className="text-xs text-zinc-400">No data</div>
             )}

--- a/app/roaster/page.tsx
+++ b/app/roaster/page.tsx
@@ -275,7 +275,7 @@ export default function RoasterPage() {
   const init = getRoasterState()
   const [result, setResult] = useState<Result | null>(null)
   const [level, setLevel] = useState(init.level)
-  const [roast, setRoast] = useState<Comment[] | null>(null)
+  const [roast, setRoast] = useState<Comment[] | null>(init.roast)
   const [widgets, setWidgets] = useState<Record<Department, Comment>>(init.widgets)
   const [roasting, setRoasting] = useState(false)
   const [ointWidgets, setOintWidgets] = useState<Record<Department, Comment> | null>(init.ointWidgets)
@@ -291,8 +291,8 @@ export default function RoasterPage() {
   }, [])
 
   useEffect(() => {
-    setRoasterState({ level, widgets, ointWidgets, healed, steps: ointSteps })
-  }, [level, widgets, ointWidgets, healed, ointSteps])
+    setRoasterState({ level, widgets, ointWidgets, healed, steps: ointSteps, roast })
+  }, [level, widgets, ointWidgets, healed, ointSteps, roast])
 
   async function runRoaster() {
     if (!result) return

--- a/app/toolset/page.tsx
+++ b/app/toolset/page.tsx
@@ -1,6 +1,19 @@
 'use client'
 import { useState } from 'react'
 import { Card, Badge, Metric } from '../../lib/ui'
+import dynamic from 'next/dynamic'
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend
+} from 'chart.js'
+
+ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend)
+const Radar = dynamic(() => import('react-chartjs-2').then(m => m.Radar), { ssr: false })
 import type { DashboardData } from '../../lib/types.oint'
 import HexBackground from '../../components/HexBackground'
 import { getOintData, setOintData } from '../../lib/toolsetState'
@@ -180,6 +193,40 @@ export default function ToolsetPage() {
                   <Metric label="Coverage" value={data.reliability.coveragePct} />
                   <Metric label="Evidence" value={data.reliability.evidenceCompletenessPct} />
                   <Metric label="LLM Agreement" value={data.reliability.llmStaticAgreementPct} />
+                </div>
+                <div className="mt-4">
+                  <Radar
+                    data={{
+                      labels: ['Coverage', 'Evidence', 'LLM Agreement'],
+                      datasets: [
+                        {
+                          label: 'Reliability',
+                          data: [
+                            data.reliability.coveragePct,
+                            data.reliability.evidenceCompletenessPct,
+                            data.reliability.llmStaticAgreementPct
+                          ],
+                          backgroundColor: 'rgba(16,185,129,0.3)',
+                          borderColor: '#10b981',
+                          pointBackgroundColor: '#10b981',
+                          pointBorderColor: '#10b981',
+                          fill: true
+                        }
+                      ]
+                    }}
+                    options={{
+                      plugins: { legend: { display: false } },
+                      scales: {
+                        r: {
+                          beginAtZero: true,
+                          angleLines: { color: '#27272a' },
+                          grid: { color: '#27272a' },
+                          max: 100,
+                          ticks: { display: false }
+                        }
+                      }
+                    }}
+                  />
                 </div>
               </Card>
             </div>

--- a/app/toolset/page.tsx
+++ b/app/toolset/page.tsx
@@ -179,13 +179,18 @@ export default function ToolsetPage() {
               )}
               <Card>
                 <h2 className="text-lg font-semibold mb-4">30-Day Onboarding Plan</h2>
-                <ol className="list-decimal pl-5 space-y-1 text-sm">
-                  {data.onboardingPlan.map(item => (
-                    <li key={item.day}>
-                      <span className="font-medium">{item.day}:</span> {item.step}
-                    </li>
-                  ))}
-                </ol>
+                <div className="relative pl-4">
+                  <div className="absolute left-1 top-0 bottom-0 w-px bg-emerald-700/50" />
+                  <ul className="space-y-4">
+                    {data.onboardingPlan.map(item => (
+                      <li key={item.day} className="relative pl-6">
+                        <span className="absolute left-1 top-1 w-2 h-2 rounded-full bg-emerald-500" />
+                        <div className="text-xs text-emerald-400 font-medium">{item.day}</div>
+                        <div className="text-sm text-zinc-300">{item.step}</div>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </Card>
               <Card>
                 <h2 className="text-lg font-semibold mb-4">Reliability Gate</h2>

--- a/lib/roasterState.ts
+++ b/lib/roasterState.ts
@@ -13,6 +13,7 @@ export type RoasterState = {
   ointWidgets: Record<Department, Comment> | null
   healed: boolean
   steps: string[]
+  roast: Comment[] | null
 }
 
 let state: RoasterState = {
@@ -20,7 +21,8 @@ let state: RoasterState = {
   widgets: empty,
   ointWidgets: null,
   healed: false,
-  steps: []
+  steps: [],
+  roast: null
 }
 
 export function getRoasterState(): RoasterState {


### PR DESCRIPTION
## Summary
- derive actionable OINT recommendations from docs and roast feedback
- swap matrix category pie chart with radar visualization in OINT green
- ingest GitHub repos using default branch without manual selection and chart reliability metrics on toolset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8a8c61dfc8322af6eda0b60d1da3f