### PR TITLE
Expand OINT insights and dashboard widgets

### DIFF
--- a/app/api/oint/apply/route.ts
+++ b/app/api/oint/apply/route.ts
@@ -8,7 +8,19 @@ export async function POST(req: Request) {
 
   const body = await req.json().catch(() => ({}))
   const roast = Array.isArray(body.roast) ? body.roast : []
-  const { docs, files } = getKnowledge()
+
+  let { docs, files } = getKnowledge()
+  if (body.knowledge) {
+    const k = body.knowledge
+    if (Array.isArray(k.docs) && Array.isArray(k.files)) {
+      docs = k.docs.map((d: any) => ({
+        name: d.name,
+        text: (d.text || d.content || '').toString()
+      }))
+      files = k.files
+    }
+  }
+
   const docText = docs.map(d => d.text.toLowerCase()).join(' ')
 
   const STOP = new Set(

--- a/app/api/oint/summary/route.ts
+++ b/app/api/oint/summary/route.ts
@@ -43,6 +43,22 @@ export async function GET() {
       rationale: 'No companion tests detected for key source files'
     })
   }
+  if (files.length > 100) {
+    actions.push({
+      id: 'act-audit',
+      title: 'Audit large codebase for dead code',
+      severity: 'medium',
+      rationale: `Repository contains ${files.length} files`
+    })
+  }
+  if (!files.some(f => /readme/i.test(f))) {
+    actions.push({
+      id: 'act-readme',
+      title: 'Add a project README',
+      severity: 'low',
+      rationale: 'No README detected in repository'
+    })
+  }
   if (actions.length === 0) {
     actions.push({
       id: 'act-review',
@@ -52,15 +68,30 @@ export async function GET() {
     })
   }
 
-  const onboardingPlan = docs.map((d, i) => ({
-    day: `Day ${i + 1}`,
-    step: `Review ${d.name}`
-  }))
-  const planFiles = files.filter(f => /\.(js|ts|jsx|tsx|py|rb|go|java|rs)$/i.test(f))
-  const remaining = 10 - onboardingPlan.length
-  planFiles.slice(0, remaining).forEach(f => {
-    onboardingPlan.push({ day: `Day ${onboardingPlan.length + 1}`, step: `Explore ${f}` })
-  })
+  const onboardingPlan: DashboardData['onboardingPlan'] = [
+    {
+      day: 'Days 1-5',
+      step: `Meet stakeholders and review ${docs.length} key docs`
+    },
+    {
+      day: 'Days 6-10',
+      step: `Explore codebase starting with ${files[0] || 'core modules'}`
+    },
+    { day: 'Days 11-15', step: 'Align on project goals and metrics' },
+    { day: 'Days 16-20', step: 'Establish team processes and priorities' },
+    { day: 'Days 21-25', step: 'Tackle high severity actions and quick wins' },
+    { day: 'Days 26-30', step: 'Plan next iteration and present findings' }
+  ]
+
+  const complexity = Math.ceil(files.length / 20)
+  const executionDays = Math.min(15, Math.max(5, complexity * 5))
+  const wrapDays = Math.max(0, 30 - 10 - executionDays)
+  const timeline = [
+    { phase: 'Orientation', days: 5 },
+    { phase: 'Planning', days: 5 },
+    { phase: 'Execution', days: executionDays },
+    { phase: 'Wrap-up', days: wrapDays }
+  ]
 
   const data: DashboardData = {
     generatedAt: new Date().toISOString(),
@@ -78,6 +109,7 @@ export async function GET() {
     },
     actions,
     onboardingPlan,
+    timeline,
     reliability: {
       coveragePct: coverage,
       evidenceCompletenessPct: Math.round((docs.length / 5) * 100),

--- a/app/roaster/page.tsx
+++ b/app/roaster/page.tsx
@@ -333,7 +333,7 @@ export default function RoasterPage() {
       const res = await fetch('/api/oint/apply', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ roast })
+        body: JSON.stringify({ roast, knowledge: result })
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'apply OINT failed')

--- a/app/toolset/page.tsx
+++ b/app/toolset/page.tsx
@@ -164,9 +164,12 @@ export default function ToolsetPage() {
                 <h2 className="text-lg font-semibold mb-4">Actions</h2>
                 <ul className="space-y-2">
                   {data.actions.map(a => (
-                    <li key={a.id} className="flex items-center gap-2 text-sm">
-                      <Badge className={`${severityColor(a.severity)} text-white`}>{a.severity}</Badge>
-                      <span className="font-medium">{a.title}</span>
+                    <li key={a.id} className="text-sm">
+                      <div className="flex items-center gap-2">
+                        <Badge className={`${severityColor(a.severity)} text-white`}>{a.severity}</Badge>
+                        <span className="font-medium">{a.title}</span>
+                      </div>
+                      <div className="text-xs text-zinc-400 ml-6">{a.rationale}</div>
                     </li>
                   ))}
                 </ul>
@@ -174,9 +177,36 @@ export default function ToolsetPage() {
               {data.finance && (
                 <Card>
                   <h2 className="text-lg font-semibold mb-2">Finance</h2>
-                  <p className="text-sm">Budget effectiveness: {data.finance.effectivenessPct}%</p>
+                  <div className="space-y-2">
+                    <div className="h-2 bg-zinc-700 rounded">
+                      <div
+                        className="h-full bg-emerald-500 rounded"
+                        style={{ width: `${data.finance.effectivenessPct}%` }}
+                      />
+                    </div>
+                    <p className="text-xs text-zinc-400">
+                      Budget effectiveness: {data.finance.effectivenessPct}%
+                    </p>
+                  </div>
                 </Card>
               )}
+              <Card>
+                <h2 className="text-lg font-semibold mb-4">Timeline Estimate</h2>
+                <ul className="space-y-3">
+                  {data.timeline.map(t => (
+                    <li key={t.phase}>
+                      <div className="text-sm font-medium">{t.phase}</div>
+                      <div className="h-2 bg-zinc-700 rounded">
+                        <div
+                          className="h-full bg-emerald-500 rounded"
+                          style={{ width: `${(t.days / 30) * 100}%` }}
+                        />
+                      </div>
+                      <div className="text-xs text-zinc-400 mt-1">{t.days} days</div>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
               <Card>
                 <h2 className="text-lg font-semibold mb-4">30-Day Onboarding Plan</h2>
                 <div className="relative pl-4">
@@ -199,7 +229,7 @@ export default function ToolsetPage() {
                   <Metric label="Evidence" value={data.reliability.evidenceCompletenessPct} />
                   <Metric label="LLM Agreement" value={data.reliability.llmStaticAgreementPct} />
                 </div>
-                <div className="mt-4">
+                <div className="mt-4 w-60 h-60 mx-auto">
                   <Radar
                     data={{
                       labels: ['Coverage', 'Evidence', 'LLM Agreement'],
@@ -229,7 +259,8 @@ export default function ToolsetPage() {
                           max: 100,
                           ticks: { display: false }
                         }
-                      }
+                      },
+                      maintainAspectRatio: false
                     }}
                   />
                 </div>

--- a/lib/types.oint.ts
+++ b/lib/types.oint.ts
@@ -2,6 +2,7 @@ export type ActionItem = { id: string; title: string; severity: 'critical'|'high
 export type StackInfo = { appName: string; description: string; integrations: { name: string; logoUrl?: string }[] };
 export type FinanceInfo = { effectivenessPct: number };
 export type PlanItem = { day: string; step: string };
+export type TimelineItem = { phase: string; days: number };
 export type DashboardData = {
   generatedAt: string;
   pulse: {
@@ -14,6 +15,7 @@ export type DashboardData = {
   stack: StackInfo;
   actions: ActionItem[];
   onboardingPlan: PlanItem[];
+  timeline: TimelineItem[];
   reliability: { coveragePct: number; evidenceCompletenessPct: number; llmStaticAgreementPct: number };
   finance?: FinanceInfo;
 };


### PR DESCRIPTION
## Summary
- send cached repo knowledge with Apply OINT requests
- generate richer OINT summary including timeline and management-focused onboarding plan
- enhance dashboard UI with action rationales, finance and timeline visuals, and smaller reliability chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8ba8e72708322ac01e7441ae94154