### PR TITLE
fix: keep face behind OINT results

### DIFF
--- a/app/roaster/page.tsx
+++ b/app/roaster/page.tsx
@@ -393,7 +393,7 @@ export default function RoasterPage() {
       </div>
       {level > 0.95 && <FireLayer />}
       <div
-        className="absolute -bottom-40 -right-40 z-10 no-hex"
+        className="absolute -bottom-40 -right-40 -z-10 no-hex"
         aria-hidden="true"
         style={{ transform: 'scale(3)', transformOrigin: 'bottom right' }}
       >


### PR DESCRIPTION
## Summary
- ensure face graphic sits behind OINT action containers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9f90122a48322847b1b7ff00fac28