### PR TITLE
Add themed privacy policy page

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,17 +1,366 @@
 // @ts-nocheck
-import { readFile } from 'fs/promises'
-import { marked } from 'marked'
 import HexBackground from '../../components/HexBackground'
 
-export default async function PrivacyPage() {
-  const md = await readFile(process.cwd() + '/privacy.md', 'utf8')
-  const html = marked.parse(md)
+const sectionClass =
+  'rounded-2xl border border-cyan-500/20 bg-zinc-900/70 p-6 md:p-8 shadow-lg shadow-cyan-500/10 backdrop-blur'
+
+export default function PrivacyPage() {
+  const sections = [
+    {
+      title: '1. Introduction',
+      content: (
+        <p className="text-zinc-200">
+          OINTment is a web-based application that helps developers and teams understand and
+          improve their software projects by ingesting source code and documents, mapping
+          dependencies and commit history, and producing AI-generated analyses. This privacy
+          policy explains how OINTment (referred to as “we” or “us”) collects, uses, shares, and
+          protects your personal data when you use the application. It also describes your rights
+          under the EU General Data Protection Regulation (GDPR).
+        </p>
+      ),
+    },
+    {
+      title: '2. Who is the data controller?',
+      content: (
+        <p className="text-zinc-200">
+          The data controller is the entity that determines the purposes and means of the
+          processing of personal data. OINTment is currently operated by Pineapple-Chunks Studio
+          (contact email: privacy@pineapplechunks.studio). If the operation of the app changes or
+          if a partner organisation is designated as the controller, we will update this notice
+          accordingly.
+        </p>
+      ),
+    },
+    {
+      title: '3. Personal data we collect and why',
+      content: (
+        <div className="space-y-6 text-zinc-200">
+          <div>
+            <h3 className="font-semibold text-cyan-300">3.1 Data you provide directly</h3>
+            <ul className="mt-3 list-disc space-y-2 pl-6 text-sm md:text-base">
+              <li>
+                <strong>Repository details –</strong> When you submit a repository URL (e.g. owner/repo)
+                or upload a ZIP archive via the /ingest endpoint, the form data includes the
+                repository name and branch, or your uploaded file. We use this data to fetch your
+                code from GitHub or to read your uploaded archive. The ingest route checks the repo
+                and branch parameters and obtains a ZIP file from GitHub or from your upload.
+              </li>
+              <li>
+                <strong>Documentation –</strong> You may upload project documentation (e.g. PRD, design
+                estimates) alongside code. These files are read, converted to text, and truncated
+                to the first 10,000 characters. We store only the extracted text, file names, and
+                document type, as provided in the docs_meta form field.
+              </li>
+              <li>
+                <strong>GitHub authentication token –</strong> If you authorize OINTment to access a private
+                repository, a GitHub personal access token is included either in the request header
+                (x-github-token) or as a github_token cookie. We do not store your token beyond the
+                duration of your session; it is kept in a secure cookie and used only to fetch
+                repository content.
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold text-cyan-300">3.2 Data we collect automatically</h3>
+            <ul className="mt-3 list-disc space-y-2 pl-6 text-sm md:text-base">
+              <li>
+                <strong>Repository file list and code snippets –</strong> During ingestion, the application
+                downloads the repository ZIP file, extracts the list of file names, and loads the
+                contents of each file (truncated to 10,000 characters). This data is necessary to
+                build dependency graphs, run AI analyses, and provide visualisations.
+              </li>
+              <li>
+                <strong>Commit metadata –</strong> To create the 3D commit map and to classify commits,
+                OINTment may fetch commit hashes, authors, timestamps, commit messages, and changed
+                paths from GitHub. Commit messages and metadata are passed to AI models for
+                classification and jitter calculation.
+              </li>
+              <li>
+                <strong>Analysis results –</strong> AI-generated summaries, code reviews (“roasts”), fix
+                suggestions, and AI-artifact detection results are returned from the AI provider and
+                stored in the app to display to you.
+              </li>
+              <li>
+                <strong>Cookies and session data –</strong> We use cookies to manage your session and
+                authentication. The github_token cookie stores your GitHub access token so that
+                requests to GitHub can be authenticated. Additional session cookies may be used to
+                maintain state and to implement CSRF protection. These cookies are essential to the
+                operation of the app and do not track you for advertising purposes.
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold text-cyan-300">3.3 Data from third parties</h3>
+            <ul className="mt-3 list-disc space-y-2 pl-6 text-sm md:text-base">
+              <li>
+                <strong>GitHub –</strong> When you provide a repository URL, we request metadata (e.g.
+                default branch) and download the repository archive from GitHub’s codeload domain.
+                This may include commit history and contributor information that contains names and
+                email addresses. This data is used solely to perform the requested analyses.
+              </li>
+              <li>
+                <strong>OpenAI/AIML API –</strong> To generate summaries, reviews, and classifications, we
+                send portions of your repository file list, documentation, commit messages, and code
+                snippets to an AI API operated by OpenAI or an alternative AI provider, as
+                configured in the environment variables. The AI provider processes this data to
+                return the requested analysis.
+              </li>
+            </ul>
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: '4. How we use your personal data',
+      content: (
+        <ul className="list-disc space-y-2 pl-6 text-zinc-200 text-sm md:text-base">
+          <li>
+            Provide and improve the service – ingest your repository, parse files and documentation,
+            fetch commit history, and display dependency graphs, matrices, and commit maps while
+            generating AI-assisted summaries and recommendations.
+          </li>
+          <li>Authenticate requests using your GitHub token to access private repositories.</li>
+          <li>
+            Generate analyses using AI by sending file lists, code snippets, and commit data to AI
+            models.
+          </li>
+          <li>Communicate with you regarding service-related announcements or enquiries.</li>
+          <li>Ensure security, detect abuse, debug issues, and improve stability.</li>
+          <li>We do not use your personal data for advertising or marketing purposes.</li>
+        </ul>
+      ),
+    },
+    {
+      title: '5. Legal basis for processing',
+      content: (
+        <div className="space-y-4 text-zinc-200">
+          <p>
+            We rely on the following legal bases under the GDPR when processing personal data:
+          </p>
+          <ul className="list-disc space-y-2 pl-6 text-sm md:text-base">
+            <li>
+              <strong>Consent (Article 6(1)(a)) –</strong> By uploading code or providing a repository URL
+              and a GitHub token, you consent to our processing of that data for the purposes
+              described in this policy. You may withdraw your consent at any time by stopping use of
+              the app and clearing the github_token cookie. This will not affect processing that
+              took place before your withdrawal.
+            </li>
+            <li>
+              <strong>Legitimate interests (Article 6(1)(f)) –</strong> We have a legitimate interest in
+              analysing code and commit history to provide insights to our users, to ensure the
+              security of the platform, and to improve our services. When we rely on this basis, we
+              assess whether our interests are overridden by your fundamental rights and freedoms.
+            </li>
+            <li>
+              <strong>Contract performance (Article 6(1)(b)) –</strong> If we enter into a contract with you
+              (e.g. a paid subscription or enterprise agreement), we process personal data to
+              perform that contract.
+            </li>
+          </ul>
+        </div>
+      ),
+    },
+    {
+      title: '6. How we share your data',
+      content: (
+        <ul className="list-disc space-y-2 pl-6 text-zinc-200 text-sm md:text-base">
+          <li>
+            <strong>AI service providers –</strong> We send repository content (file lists, documentation,
+            code snippets, commit messages, and metadata) to AI models hosted by OpenAI or other
+            providers to obtain summaries and analyses. These providers act as data processors on
+            our behalf and are bound to use your data only to provide the requested analysis.
+          </li>
+          <li>
+            <strong>Hosting and infrastructure providers –</strong> These partners process logs and metadata
+            to deliver the service securely and reliably.
+          </li>
+          <li>
+            <strong>GitHub –</strong> When you provide a repository URL or token, we request repository
+            archives, commit histories, and related metadata from GitHub’s APIs. GitHub is a separate
+            data controller for the content of repositories.
+          </li>
+          <li>
+            <strong>Legal or regulatory authorities –</strong> We may disclose personal data if required by
+            law, regulation, legal process, or to protect the rights, property, or safety of
+            OINTment or others.
+          </li>
+          <li>We do not sell your personal data to third parties.</li>
+        </ul>
+      ),
+    },
+    {
+      title: '7. International transfers',
+      content: (
+        <p className="text-zinc-200">
+          The AI providers and hosting services we use may be located outside of the European
+          Economic Area (EEA). When personal data is transferred to a country that does not have an
+          adequacy decision from the European Commission, we ensure appropriate safeguards are in
+          place, such as Standard Contractual Clauses (SCCs) or another lawful transfer mechanism. A
+          copy of these safeguards can be provided upon request.
+        </p>
+      ),
+    },
+    {
+      title: '8. Data retention',
+      content: (
+        <div className="space-y-3 text-zinc-200">
+          <p>We retain your personal data only for as long as necessary to fulfil the purposes above:</p>
+          <ul className="list-disc space-y-2 pl-6 text-sm md:text-base">
+            <li>
+              Uploaded archives and extracted code snippets are processed in memory and are not
+              stored beyond the current session unless you explicitly save the analysis. Temporary
+              buffers are cleared when the response is returned.
+            </li>
+            <li>
+              Analysis results (e.g. summaries, roasts, suggestions) may be kept in your session for
+              convenience. If you have an account, we may retain these results until you delete the
+              project or your account.
+            </li>
+            <li>
+              Logs containing IP addresses, timestamps, and error messages are kept for up to 90
+              days for security and debugging and then deleted or anonymised.
+            </li>
+            <li>
+              If you withdraw consent or request deletion, we will remove your data unless retention
+              is required by law or needed to protect our legal claims.
+            </li>
+          </ul>
+        </div>
+      ),
+    },
+    {
+      title: '9. Your rights under the GDPR',
+      content: (
+        <div className="space-y-3 text-zinc-200">
+          <p>Subject to certain conditions, you have the following rights:</p>
+          <ul className="list-disc space-y-2 pl-6 text-sm md:text-base">
+            <li>Right of access – request confirmation and obtain a copy of your personal data.</li>
+            <li>Right to rectification – ask us to correct inaccurate or incomplete data.</li>
+            <li>
+              Right to erasure (“right to be forgotten”) – request deletion if data is no longer
+              needed, you withdraw consent, or processing is unlawful.
+            </li>
+            <li>
+              Right to restrict processing – request that we limit processing if you contest accuracy,
+              processing is unlawful, or you need the data for legal claims.
+            </li>
+            <li>
+              Right to data portability – request your data in a structured, commonly used,
+              machine-readable format and, where technically feasible, have it transmitted to another
+              controller.
+            </li>
+            <li>
+              Right to object – object to processing based on legitimate interests on grounds relating
+              to your particular situation.
+            </li>
+            <li>
+              Right to withdraw consent – withdraw consent at any time without affecting previous
+              processing.
+            </li>
+            <li>
+              Right not to be subject to automated decision-making – we do not make decisions that
+              produce legal or similarly significant effects without human involvement.
+            </li>
+          </ul>
+          <p>
+            To exercise any of these rights, contact us at{' '}
+            <a
+              href="mailto:privacy@pineapplechunks.studio"
+              className="text-cyan-300 underline decoration-dotted"
+            >
+              privacy@pineapplechunks.studio
+            </a>
+            . We may need to verify your identity before fulfilling your request.
+          </p>
+        </div>
+      ),
+    },
+    {
+      title: '10. Security measures',
+      content: (
+        <div className="space-y-3 text-zinc-200">
+          <p>We implement appropriate technical and organisational measures to protect personal data:</p>
+          <ul className="list-disc space-y-2 pl-6 text-sm md:text-base">
+            <li>Encryption in transit – All communications with OINTment occur over HTTPS.</li>
+            <li>
+              Access controls – GitHub tokens are stored in secure cookies and are not persisted in
+              our database. Only authorised personnel have access to production systems.
+            </li>
+            <li>
+              Data minimisation – We truncate code and document text to the first 10,000 characters
+              and limit the number of files sent to AI models. This reduces the amount of personal
+              data exposed.
+            </li>
+            <li>
+              Logging and monitoring – We log errors and unusual activities to detect and respond to
+              potential security incidents.
+            </li>
+          </ul>
+          <p>No system can guarantee absolute security, but we take steps to protect your data.</p>
+        </div>
+      ),
+    },
+    {
+      title: '11. Children’s privacy',
+      content: (
+        <p className="text-zinc-200">
+          OINTment is intended for professional and academic users. We do not knowingly collect
+          personal data from children under 16. If we become aware that we have collected data from
+          a child, we will delete it promptly.
+        </p>
+      ),
+    },
+    {
+      title: '12. Changes to this policy',
+      content: (
+        <p className="text-zinc-200">
+          We may update this privacy policy to reflect changes to our practices or legal
+          obligations. We will notify you of any material changes by posting the updated policy with
+          a new effective date. We encourage you to review this policy regularly.
+        </p>
+      ),
+    },
+    {
+      title: '13. Contact us',
+      content: (
+        <div className="text-zinc-200">
+          <p>
+            If you have any questions about this privacy policy or our data practices, please contact
+            us at:
+          </p>
+          <p className="mt-3 font-medium">Pineapple-Chunks Studio</p>
+          <p>Email: <a href="mailto:privacy@pineapplechunks.studio" className="text-cyan-300 underline decoration-dotted">privacy@pineapplechunks.studio</a></p>
+          <p className="mt-4">
+            Data Protection Authority – You also have the right to lodge a complaint with your local
+            supervisory authority. In Thailand, you may contact the Personal Data Protection
+            Committee (PDPC), and in the EEA you may contact your local data protection authority.
+          </p>
+        </div>
+      ),
+    },
+  ]
+
   return (
-    <div className="relative min-h-screen overflow-hidden">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-b from-zinc-950 via-black to-zinc-950">
       <HexBackground className="hex-fade" reveal={false} />
-      <div className="relative z-10 max-w-3xl mx-auto p-10 fade-in-fast">
-        <div className="rounded-2xl bg-zinc-900/60 border border-zinc-800 shadow-xl p-6 backdrop-blur-sm prose prose-invert max-w-none">
-          <div dangerouslySetInnerHTML={{ __html: html }} />
+      <div className="relative z-10 px-4 py-16 sm:px-8">
+        <div className="mx-auto max-w-5xl space-y-12">
+          <header className="text-center">
+            <p className="text-xs uppercase tracking-[0.3em] text-cyan-300">Privacy & Compliance</p>
+            <h1 className="mt-4 text-4xl font-bold text-white sm:text-5xl">Privacy Policy for OINTment</h1>
+            <p className="mt-3 text-sm text-zinc-400">Last updated: 14 September 2025</p>
+          </header>
+
+          <div className="grid gap-6">
+            {sections.map((section) => (
+              <section key={section.title} className={sectionClass}>
+                <h2 className="text-xl font-semibold text-white">{section.title}</h2>
+                <div className="mt-4 text-sm leading-relaxed text-zinc-300 md:text-base">
+                  {section.content}
+                </div>
+              </section>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -87,6 +87,13 @@ export default function PrivacyPage() {
                 maintain state and to implement CSRF protection. These cookies are essential to the
                 operation of the app and do not track you for advertising purposes.
               </li>
+              <li>
+                <strong>Local device caches –</strong> To make repeat visits faster, we store your latest
+                ingest result, repository selection, commit-map payloads (SHA, message, status, and
+                offsets), Vibe Killer results, and Mission Control dashboards in your browser’s
+                localStorage. These caches remain on your device, are never transmitted back to us,
+                and can be cleared at any time from the UI or via your browser settings.
+              </li>
             </ul>
           </div>
           <div>
@@ -107,6 +114,15 @@ export default function PrivacyPage() {
               </li>
             </ul>
           </div>
+          <div>
+            <h3 className="font-semibold text-cyan-300">3.4 Ephemeral orchestration data</h3>
+            <p className="mt-3 text-sm md:text-base">
+              <strong>OINT creation state –</strong> When you launch the Mission Control/OINT workflow, we
+              keep the uploaded documents, repository file list, and sampled code snippets in an
+              in-memory store on the server while the dashboard is assembled. This cache is discarded
+              once the response is returned and is never written to disk.
+            </p>
+          </div>
         </div>
       ),
     },
@@ -126,6 +142,11 @@ export default function PrivacyPage() {
           </li>
           <li>Communicate with you regarding service-related announcements or enquiries.</li>
           <li>Ensure security, detect abuse, debug issues, and improve stability.</li>
+          <li>
+            Run the OINT dashboard – the /api/oint endpoints reuse the in-memory document/code
+            snapshot captured during creation so that we can populate the Mission Control view
+            without re-uploading your materials.
+          </li>
           <li>We do not use your personal data for advertising or marketing purposes.</li>
         </ul>
       ),
@@ -180,6 +201,12 @@ export default function PrivacyPage() {
             data controller for the content of repositories.
           </li>
           <li>
+            <strong>Dependency metadata & logos –</strong> Opening the Architecture Matrix triggers a
+            request to the public npm registry for the dependency names extracted from your
+            repository and displays Clearbit-hosted logos for those domains. Both services receive
+            only package identifiers, never your authentication tokens.
+          </li>
+          <li>
             <strong>Legal or regulatory authorities –</strong> We may disclose personal data if required by
             law, regulation, legal process, or to protect the rights, property, or safety of
             OINTment or others.
@@ -223,6 +250,11 @@ export default function PrivacyPage() {
             <li>
               If you withdraw consent or request deletion, we will remove your data unless retention
               is required by law or needed to protect our legal claims.
+            </li>
+            <li>
+              Client-side caches (e.g. localStorage) stay on your device until you clear them from
+              the UI or your browser. In-memory orchestration data that powers the OINT dashboard is
+              automatically dropped after each request.
             </li>
           </ul>
         </div>
@@ -338,6 +370,40 @@ export default function PrivacyPage() {
         </div>
       ),
     },
+    {
+      title: '14. Technical reference: how to verify these commitments',
+      content: (
+        <div className="space-y-3 text-zinc-200">
+          <ul className="list-disc space-y-2 pl-6 text-sm md:text-base">
+            <li>
+              <strong>Repository ingest & truncation –</strong> /api/ingest receives uploaded ZIPs or
+              GitHub archives, truncates each file/doc to 10,000 characters, and forwards only the
+              file list plus docs to the LLM analyzers.
+            </li>
+            <li>
+              <strong>Commit metadata processing –</strong> /api/github/commits fetches commit SHAs,
+              statuses, and messages, classifies them through categorizeCommits/jitterOffsets, and
+              caches them locally for the 3D map.
+            </li>
+            <li>
+              <strong>Mission Control/OINT –</strong> /api/oint/create, /api/oint/summary, and
+              /api/oint/apply use an in-memory state.ts module to reuse the submitted docs/files for a
+              single dashboard session.
+            </li>
+            <li>
+              <strong>Client-side caches –</strong> Pages such as /ingest, /matrix, /3d-map, /vibe-killer,
+              /roaster, and /toolset set and read localStorage keys (ingestResult, trackingData, repo,
+              branch, vibeResult, ointData, etc.) purely within your browser.
+            </li>
+            <li>
+              <strong>Third-party lookups –</strong> /api/components queries the npm registry for package
+              metadata and returns Clearbit logo URLs, while never exposing your GitHub tokens to
+              those services.
+            </li>
+          </ul>
+        </div>
+      ),
+    },
   ]
 
   return (
@@ -348,7 +414,7 @@ export default function PrivacyPage() {
           <header className="text-center">
             <p className="text-xs uppercase tracking-[0.3em] text-cyan-300">Privacy & Compliance</p>
             <h1 className="mt-4 text-4xl font-bold text-white sm:text-5xl">Privacy Policy for OINTment</h1>
-            <p className="mt-3 text-sm text-zinc-400">Last updated: 14 September 2025</p>
+            <p className="mt-3 text-sm text-zinc-400">Last updated: 16 September 2025</p>
           </header>
 
           <div className="grid gap-6">

--- a/privacy.md
+++ b/privacy.md
@@ -1,6 +1,6 @@
 # Privacy Policy for OINTment
 
-_Last updated: 14 September 2025_
+_Last updated: 16 September 2025_
 
 ## 1. Introduction
 OINTment is a web-based application that helps developers and teams understand and improve their software projects by ingesting source code and documents, mapping dependencies and commit history, and producing AI-generated analyses. This privacy policy explains how OINTment (referred to as “we” or “us”) collects, uses, shares, and protects your personal data when you use the application. It also describes your rights under the EU General Data Protection Regulation (GDPR).
@@ -19,10 +19,14 @@ The data controller is the entity that determines the purposes and means of the 
 - **Commit metadata** – To create the 3D commit map and to classify commits, OINTment may fetch commit hashes, authors, timestamps, commit messages, and changed paths from GitHub. Commit messages and metadata are passed to AI models for classification and jitter calculation.
 - **Analysis results** – AI-generated summaries, code reviews (“roasts”), fix suggestions, and AI-artifact detection results are returned from the AI provider and stored in the app to display to you.
 - **Cookies and session data** – We use cookies to manage your session and authentication. The `github_token` cookie stores your GitHub access token so that requests to GitHub can be authenticated. Additional session cookies may be used to maintain state and to implement CSRF protection. These cookies are essential to the operation of the app and do not track you for advertising purposes.
+- **Local device caches** – To make repeat visits faster, we store your latest ingest result, repository selection, commit-map payloads (SHA, message, status and offsets), Vibe Killer results and Mission Control dashboards in your browser’s `localStorage`. These caches remain on your device, are never transmitted back to us, and can be cleared at any time from the UI or via your browser settings.
 
 ### 3.3 Data from third parties
 - **GitHub** – When you provide a repository URL, we request metadata (e.g. default branch) and download the repository archive from GitHub’s `codeload` domain. This may include commit history and contributor information that contains names and email addresses. This data is used solely to perform the requested analyses.
 - **OpenAI/AIML API** – To generate summaries, reviews, and classifications, we send portions of your repository file list, documentation, commit messages, and code snippets to an AI API operated by OpenAI or an alternative AI provider, as configured in the environment variables. The AI provider processes this data to return the requested analysis.
+
+### 3.4 Ephemeral orchestration data
+- **OINT creation state** – When you launch the Mission Control/OINT workflow, we keep the uploaded documents, repository file list and sampled code snippets in an in-memory store on the server while the dashboard is assembled. This cache is discarded once the response is returned and is never written to disk.
 
 ## 4. How we use your personal data
 We process personal data to:
@@ -31,6 +35,7 @@ We process personal data to:
 - **Generate analyses using AI** – We send file lists, code snippets, and commit data to AI models to generate summaries, code reviews, fix suggestions, and AI-artifact detection results.
 - **Communicate with you** – We may use your contact information (if provided separately) to send service-related announcements or to respond to your enquiries.
 - **Ensure security and prevent misuse** – We log certain actions (e.g. ingestion requests, authentication errors) to detect abuse, debug issues, and improve stability.
+- **Run the OINT dashboard** – The `/api/oint` endpoints reuse the in-memory document/code snapshot captured during creation so that we can populate the Mission Control view without re-uploading your materials.
 
 We do not use your personal data for advertising or marketing purposes.
 
@@ -45,6 +50,7 @@ We may share your personal data with the following categories of recipients:
 - **AI service providers** – We send content extracted from your repository (file lists, documentation, code snippets, commit messages, and metadata) to AI models hosted by OpenAI or other providers to obtain summaries and analyses. These providers act as data processors on our behalf and are contractually bound to use your data only to provide the requested analysis.
 - **Hosting and infrastructure providers** – OINTment is hosted on cloud infrastructure. These providers may process logs and metadata to deliver the service securely and reliably.
 - **GitHub** – When you provide a repository URL or token, we request repository archives, commit histories, and related metadata from GitHub’s APIs. GitHub is a separate data controller for the content of repositories.
+- **Dependency metadata & logos** – When you open the Architecture Matrix, we query the public npm registry for the dependency names extracted from your repository and display Clearbit-hosted logos for those domains. Both services receive only package identifiers, never your authentication tokens.
 - **Legal or regulatory authorities** – We may disclose personal data if required by law, regulation, legal process, or to protect the rights, property, or safety of OINTment or others.
 
 We do not sell your personal data to third parties.
@@ -58,6 +64,7 @@ We retain your personal data only for as long as necessary to fulfil the purpose
 - Analysis results (e.g. summaries, roasts, suggestions) may be kept in your session for convenience. If you have an account, we may retain these results until you delete the project or your account.
 - Logs containing IP addresses, timestamps, and error messages are kept for up to 90 days for security and debugging and then deleted or anonymised.
 - If you withdraw consent or request deletion, we will remove your data unless retention is required by law or needed to protect our legal claims.
+- Client-side caches (e.g. `localStorage`) stay on your device until you clear them from the UI or your browser. In-memory orchestration data that powers the OINT dashboard is automatically dropped after each request.
 
 ## 9. Your rights under the GDPR
 Subject to certain conditions, you have the following rights:
@@ -94,3 +101,10 @@ If you have any questions about this privacy policy or our data practices, pleas
 Email: `privacy@pineapplechunks.studio`
 
 Data Protection Authority – You also have the right to lodge a complaint with your local supervisory authority. In Thailand, you may contact the Personal Data Protection Committee (PDPC), and in the EEA you may contact your local data protection authority.
+
+## 14. Technical reference: how to verify these commitments
+- **Repository ingest & truncation** – `/api/ingest` receives uploaded ZIPs or GitHub archives, truncates each file/doc to 10,000 characters, and forwards only the file list plus docs to the LLM analyzers.
+- **Commit metadata processing** – `/api/github/commits` fetches commit SHAs, statuses and messages, classifies them through `categorizeCommits`/`jitterOffsets`, and caches them locally for the 3D map.
+- **Mission Control/OINT** – `/api/oint/create`, `/api/oint/summary`, and `/api/oint/apply` use an in-memory `state.ts` module to reuse the submitted docs/files for a single dashboard session.
+- **Client-side caches** – Pages such as `/ingest`, `/matrix`, `/3d-map`, `/vibe-killer`, `/roaster`, and `/toolset` set and read `localStorage` keys (`ingestResult`, `trackingData`, `repo`, `branch`, `vibeResult`, `ointData`, etc.) purely within your browser.
+- **Third-party lookups** – `/api/components` queries the npm registry for package metadata and returns Clearbit logo URLs, while never exposing your GitHub tokens to those services.

--- a/privacy.md
+++ b/privacy.md
@@ -1,118 +1,96 @@
 # Privacy Policy for OINTment
-Last updated: 14 September 2025
+
+_Last updated: 14 September 2025_
 
 ## 1. Introduction
-OINTment is a web‑based application that helps developers and teams understand and improve their software projects by ingesting source code and documents, mapping dependencies and commit history, and producing AI‑generated analyses. This privacy policy explains how OINTment (referred to in this policy as "we" or "us") collects, uses, shares and protects your personal data when you use the application. It also describes your rights under the EU General Data Protection Regulation (GDPR).
-
----
+OINTment is a web-based application that helps developers and teams understand and improve their software projects by ingesting source code and documents, mapping dependencies and commit history, and producing AI-generated analyses. This privacy policy explains how OINTment (referred to as “we” or “us”) collects, uses, shares, and protects your personal data when you use the application. It also describes your rights under the EU General Data Protection Regulation (GDPR).
 
 ## 2. Who is the data controller?
-The data controller is the entity that determines the purposes and means of the processing of personal data. OINTment is currently operated by **Pineapple‑Chunks Studio** (contact email: `privacy@ointment.dev`). If the operation of the app changes or if a partner organisation is designated as the controller, we will update this notice accordingly.
-
----
+The data controller is the entity that determines the purposes and means of the processing of personal data. OINTment is currently operated by **Pineapple-Chunks Studio** (contact email: `privacy@pineapplechunks.studio`). If the operation of the app changes or if a partner organisation is designated as the controller, we will update this notice accordingly.
 
 ## 3. Personal data we collect and why
-
 ### 3.1 Data you provide directly
-* **Repository details** – When you submit a repository URL (e.g. `owner/repo`) or upload a ZIP archive via the `/ingest` endpoint, the form data includes the repository name and branch, or your uploaded file. We use this data to fetch your code from GitHub or to read your uploaded archive. The ingest route checks the repo and branch parameters and obtains a ZIP file from GitHub or from your upload.
-* **Documentation** – You may upload project documentation (e.g. PRD, design estimates) alongside code. These files are read, converted to text and truncated to the first 10,000 characters. We store only the extracted text, file names and the type of document, as provided in the `docs_meta` form field.
-* **GitHub authentication token** – If you authorize OINTment to access a private repository, a GitHub personal access token is included either in the request header (`x‑github-token`) or as a `github_token` cookie. The `githubHeaders` helper reads this token to make authenticated requests to GitHub. We do not store your token beyond the duration of your session; it is kept in a secure cookie and used only to fetch repository content.
+- **Repository details** – When you submit a repository URL (e.g. `owner/repo`) or upload a ZIP archive via the `/ingest` endpoint, the form data includes the repository name and branch, or your uploaded file. We use this data to fetch your code from GitHub or to read your uploaded archive. The ingest route checks the repo and branch parameters and obtains a ZIP file from GitHub or from your upload.
+- **Documentation** – You may upload project documentation (e.g. PRD, design estimates) alongside code. These files are read, converted to text, and truncated to the first 10,000 characters. We store only the extracted text, file names, and the type of document, as provided in the `docs_meta` form field.
+- **GitHub authentication token** – If you authorize OINTment to access a private repository, a GitHub personal access token is included either in the request header (`x-github-token`) or as a `github_token` cookie. We do not store your token beyond the duration of your session; it is kept in a secure cookie and used only to fetch repository content.
 
 ### 3.2 Data we collect automatically
-* **Repository file list and code snippets** – During ingestion, the application downloads the repository ZIP file, extracts the list of file names and loads the contents of each file (truncated to 10,000 characters). This data is necessary to build dependency graphs, run AI analyses and provide visualisations.
-* **Commit metadata** – To create the 3D commit map and to classify commits, OINTment may fetch commit hashes, authors, timestamps, commit messages and changed paths from GitHub. Commit messages and metadata are passed to AI models for classification and jitter calculation.
-* **Analysis results** – AI‑generated summaries, code reviews ("roasts"), fix suggestions and AI‑artifact detection results are returned from the AI provider and stored in the app to display to you. The `summarizeRepo` function, for example, sends the file list and documentation to an AI model and parses the returned JSON. Similar functions produce roasts, improvement steps and commit classifications.
-* **Cookies and session data** – We use cookies to manage your session and authentication. The `github_token` cookie stores your GitHub access token so that requests to GitHub can be authenticated. Additional session cookies may be used to maintain state (e.g. which repository you are working on) and to implement CSRF protection. These cookies are essential to the operation of the app and do not track you for advertising purposes.
+- **Repository file list and code snippets** – During ingestion, the application downloads the repository ZIP file, extracts the list of file names, and loads the contents of each file (truncated to 10,000 characters). This data is necessary to build dependency graphs, run AI analyses, and provide visualisations.
+- **Commit metadata** – To create the 3D commit map and to classify commits, OINTment may fetch commit hashes, authors, timestamps, commit messages, and changed paths from GitHub. Commit messages and metadata are passed to AI models for classification and jitter calculation.
+- **Analysis results** – AI-generated summaries, code reviews (“roasts”), fix suggestions, and AI-artifact detection results are returned from the AI provider and stored in the app to display to you.
+- **Cookies and session data** – We use cookies to manage your session and authentication. The `github_token` cookie stores your GitHub access token so that requests to GitHub can be authenticated. Additional session cookies may be used to maintain state and to implement CSRF protection. These cookies are essential to the operation of the app and do not track you for advertising purposes.
 
 ### 3.3 Data from third parties
-* **GitHub** – When you provide a repository URL, we request metadata (e.g. default branch) and download the repository archive from GitHub’s `codeload` domain. This may include commit history and contributor information that contains names and email addresses. This data is used solely to perform the requested analyses.
-* **OpenAI/AIML API** – To generate summaries, reviews and classifications, we send portions of your repository file list, documentation, commit messages and code snippets to an AI API operated by OpenAI or an alternative AI provider, as configured in the environment variables. The AI provider processes this data to return the requested analysis.
-
----
+- **GitHub** – When you provide a repository URL, we request metadata (e.g. default branch) and download the repository archive from GitHub’s `codeload` domain. This may include commit history and contributor information that contains names and email addresses. This data is used solely to perform the requested analyses.
+- **OpenAI/AIML API** – To generate summaries, reviews, and classifications, we send portions of your repository file list, documentation, commit messages, and code snippets to an AI API operated by OpenAI or an alternative AI provider, as configured in the environment variables. The AI provider processes this data to return the requested analysis.
 
 ## 4. How we use your personal data
 We process personal data to:
-* **Provide and improve the service** – We need to ingest your repository, parse files and documentation, and fetch commit history in order to display dependency graphs, matrices and commit maps, and to generate AI‑assisted summaries and recommendations.
-* **Authenticate requests** – We use your GitHub token to authenticate API calls and to access private repositories.
-* **Generate analyses using AI** – We send file lists, code snippets and commit data to AI models to generate summaries, code reviews, fix suggestions and AI‑artifact detection results.
-* **Communicate with you** – We may use your contact information (if provided separately) to send service‑related announcements or to respond to your enquiries.
-* **Ensure security and prevent misuse** – We log certain actions (e.g. ingestion requests, authentication errors) to detect abuse, debug issues and improve stability.
+- **Provide and improve the service** – We ingest your repository, parse files and documentation, fetch commit history, and display dependency graphs, matrices, and commit maps while generating AI-assisted summaries and recommendations.
+- **Authenticate requests** – We use your GitHub token to authenticate API calls and to access private repositories.
+- **Generate analyses using AI** – We send file lists, code snippets, and commit data to AI models to generate summaries, code reviews, fix suggestions, and AI-artifact detection results.
+- **Communicate with you** – We may use your contact information (if provided separately) to send service-related announcements or to respond to your enquiries.
+- **Ensure security and prevent misuse** – We log certain actions (e.g. ingestion requests, authentication errors) to detect abuse, debug issues, and improve stability.
 
 We do not use your personal data for advertising or marketing purposes.
 
----
-
 ## 5. Legal basis for processing
 We rely on the following legal bases under the GDPR:
-* **Consent (Article 6(1)(a))** – By uploading code or providing a repository URL and a GitHub token, you consent to our processing of that data for the purposes described in this policy. You may withdraw your consent at any time by stopping use of the app and clearing the `github_token` cookie. This will not affect processing that took place before your withdrawal.
-* **Legitimate interests (Article 6(1)(f))** – We have a legitimate interest in analysing code and commit history to provide insights to our users, to ensure the security of the platform and to improve our services. When we rely on this basis, we assess whether our interests are overridden by your fundamental rights and freedoms.
-* **Contract performance (Article 6(1)(b))** – If we enter into a contract with you (e.g. a paid subscription or enterprise agreement), we process personal data to perform that contract.
-
----
+- **Consent (Article 6(1)(a))** – By uploading code or providing a repository URL and a GitHub token, you consent to our processing of that data for the purposes described in this policy. You may withdraw your consent at any time by stopping use of the app and clearing the `github_token` cookie. This will not affect processing that took place before your withdrawal.
+- **Legitimate interests (Article 6(1)(f))** – We have a legitimate interest in analysing code and commit history to provide insights to our users, to ensure the security of the platform, and to improve our services. When we rely on this basis, we assess whether our interests are overridden by your fundamental rights and freedoms.
+- **Contract performance (Article 6(1)(b))** – If we enter into a contract with you (e.g. a paid subscription or enterprise agreement), we process personal data to perform that contract.
 
 ## 6. How we share your data
 We may share your personal data with the following categories of recipients:
-* **AI service providers** – We send content extracted from your repository (file lists, documentation, code snippets, commit messages and metadata) to AI models hosted by OpenAI or other providers to obtain summaries and analyses. These providers act as data processors on our behalf and are contractually bound to use your data only to provide the requested analysis.
-* **Hosting and infrastructure providers** – OINTment is hosted on cloud infrastructure. These providers may process logs and metadata to deliver the service securely and reliably.
-* **GitHub** – When you provide a repository URL or token, we request repository archives, commit histories and related metadata from GitHub’s APIs. GitHub is a separate data controller for the content of repositories.
-* **Legal or regulatory authorities** – We may disclose personal data if required by law, regulation or legal process, or to protect the rights, property or safety of OINTment or others.
+- **AI service providers** – We send content extracted from your repository (file lists, documentation, code snippets, commit messages, and metadata) to AI models hosted by OpenAI or other providers to obtain summaries and analyses. These providers act as data processors on our behalf and are contractually bound to use your data only to provide the requested analysis.
+- **Hosting and infrastructure providers** – OINTment is hosted on cloud infrastructure. These providers may process logs and metadata to deliver the service securely and reliably.
+- **GitHub** – When you provide a repository URL or token, we request repository archives, commit histories, and related metadata from GitHub’s APIs. GitHub is a separate data controller for the content of repositories.
+- **Legal or regulatory authorities** – We may disclose personal data if required by law, regulation, legal process, or to protect the rights, property, or safety of OINTment or others.
 
 We do not sell your personal data to third parties.
-
----
 
 ## 7. International transfers
 The AI providers and hosting services we use may be located outside of the European Economic Area (EEA). When personal data is transferred to a country that does not have an adequacy decision from the European Commission, we ensure appropriate safeguards are in place, such as Standard Contractual Clauses (SCCs) or another lawful transfer mechanism. A copy of these safeguards can be provided upon request.
 
----
-
 ## 8. Data retention
 We retain your personal data only for as long as necessary to fulfil the purposes described above. Specifically:
-* Uploaded archives and extracted code snippets are processed in memory and are not stored beyond the current session unless you explicitly save the analysis. Temporary buffers are cleared when the response is returned.
-* Analysis results (e.g. summaries, roasts, suggestions) may be kept in your session for convenience. If you have an account, we may retain these results until you delete the project or your account.
-* Logs containing IP addresses, timestamps and error messages are kept for up to 90 days for security and debugging and then deleted or anonymised.
-* If you withdraw consent or request deletion, we will remove your data unless retention is required by law or needed to protect our legal claims.
-
----
+- Uploaded archives and extracted code snippets are processed in memory and are not stored beyond the current session unless you explicitly save the analysis. Temporary buffers are cleared when the response is returned.
+- Analysis results (e.g. summaries, roasts, suggestions) may be kept in your session for convenience. If you have an account, we may retain these results until you delete the project or your account.
+- Logs containing IP addresses, timestamps, and error messages are kept for up to 90 days for security and debugging and then deleted or anonymised.
+- If you withdraw consent or request deletion, we will remove your data unless retention is required by law or needed to protect our legal claims.
 
 ## 9. Your rights under the GDPR
 Subject to certain conditions, you have the following rights:
-* **Right of access** – You can request confirmation that we process your personal data and obtain a copy of that data.
-* **Right to rectification** – You can ask us to correct inaccurate or incomplete personal data.
-* **Right to erasure ("right to be forgotten")** – You can request deletion of your personal data if it is no longer needed, if you withdraw consent or if processing is unlawful.
-* **Right to restrict processing** – You can request that we restrict processing of your data if you contest its accuracy, the processing is unlawful or you need it for legal claims.
-* **Right to data portability** – You can request that we provide your data in a structured, commonly used, machine‑readable format and, where technically feasible, transmit it to another controller.
-* **Right to object** – You can object to processing based on legitimate interests on grounds relating to your particular situation. We will cease processing unless we can demonstrate compelling legitimate grounds.
-* **Right to withdraw consent** – Where we rely on consent, you may withdraw it at any time.
-* **Right not to be subject to automated decision‑making** – We do not use your data to make decisions that produce legal or similarly significant effects without human involvement.
+- **Right of access** – You can request confirmation that we process your personal data and obtain a copy of that data.
+- **Right to rectification** – You can ask us to correct inaccurate or incomplete personal data.
+- **Right to erasure (“right to be forgotten”)** – You can request deletion of your personal data if it is no longer needed, if you withdraw consent, or if processing is unlawful.
+- **Right to restrict processing** – You can request that we restrict processing of your data if you contest its accuracy, the processing is unlawful, or you need it for legal claims.
+- **Right to data portability** – You can request that we provide your data in a structured, commonly used, machine-readable format and, where technically feasible, transmit it to another controller.
+- **Right to object** – You can object to processing based on legitimate interests on grounds relating to your particular situation. We will cease processing unless we can demonstrate compelling legitimate grounds.
+- **Right to withdraw consent** – Where we rely on consent, you may withdraw it at any time.
+- **Right not to be subject to automated decision-making** – We do not use your data to make decisions that produce legal or similarly significant effects without human involvement.
 
-To exercise any of these rights, please contact us at `privacy@ointment.dev`. We may need to verify your identity before fulfilling your request.
-
----
+To exercise any of these rights, please contact us at `privacy@pineapplechunks.studio`. We may need to verify your identity before fulfilling your request.
 
 ## 10. Security measures
 We implement appropriate technical and organisational measures to protect personal data, including:
-* **Encryption in transit** – All communications with OINTment (including ingestion and API calls) occur over HTTPS.
-* **Access controls** – GitHub tokens are stored in secure cookies and are not persisted in our database. Only authorised personnel have access to production systems.
-* **Data minimisation** – We truncate code and document text to the first 10,000 characters and limit the number of files sent to AI models. This reduces the amount of personal data exposed.
-* **Logging and monitoring** – We log errors and unusual activities to detect and respond to potential security incidents.
+- **Encryption in transit** – All communications with OINTment (including ingestion and API calls) occur over HTTPS.
+- **Access controls** – GitHub tokens are stored in secure cookies and are not persisted in our database. Only authorised personnel have access to production systems.
+- **Data minimisation** – We truncate code and document text to the first 10,000 characters and limit the number of files sent to AI models. This reduces the amount of personal data exposed.
+- **Logging and monitoring** – We log errors and unusual activities to detect and respond to potential security incidents.
 
-No system can guarantee absolute security, but we take steps to protect your personal data from loss, misuse and unauthorised access.
-
----
+No system can guarantee absolute security, but we take steps to protect your personal data from loss, misuse, and unauthorised access.
 
 ## 11. Children’s privacy
 OINTment is intended for professional and academic users. We do not knowingly collect personal data from children under 16. If we become aware that we have collected data from a child, we will delete it promptly.
 
----
-
 ## 12. Changes to this policy
 We may update this privacy policy to reflect changes to our practices or legal obligations. We will notify you of any material changes by posting the updated policy with a new effective date. We encourage you to review this policy regularly.
 
----
-
 ## 13. Contact us
 If you have any questions about this privacy policy or our data practices, please contact us at:
-Pineapple‑Chunks Studio
-Email: `privacy@ointment.dev`
+
+**Pineapple-Chunks Studio**  
+Email: `privacy@pineapplechunks.studio`
+
 Data Protection Authority – You also have the right to lodge a complaint with your local supervisory authority. In Thailand, you may contact the Personal Data Protection Committee (PDPC), and in the EEA you may contact your local data protection authority.


### PR DESCRIPTION
## Summary
- replace the markdown-driven privacy route with a bespoke, themed layout that renders every section of the policy inline with the updated content and styling
- update `privacy.md` to mirror the refreshed policy text, including the latest contact information

## Testing
- `npm run lint` *(fails: script "lint" is not defined in package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d6ed15c483229a5d429d3fba7b94)